### PR TITLE
Resolve missing request ID in initialization logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ mkdir my-go-func
 cd my-go-func
 go mod init myapp
 go get github.com/azure/azure-functions-golang-worker
+go mod tidy
 ```
 
 Create a `main.go` file:

--- a/worker/dispatcher.go
+++ b/worker/dispatcher.go
@@ -23,28 +23,31 @@ func NewDispatcher(workerStartupConfig *WorkerStartupConfig, app *sdk.App) *Disp
 }
 
 func (disp *Dispatcher) processRequestMessage(reqMsg *pb.StreamingMessage) (*pb.StreamingMessage, error) {
+	requestId := disp.WorkerStartupConfig.FunctionsRequestId
+
 	switch content := reqMsg.GetContent().(type) {
 	case *pb.StreamingMessage_WorkerInitRequest:
 		log.Println("Handling WorkerInitRequest")
-		return handleWorkerInitRequest(content.WorkerInitRequest, reqMsg.RequestId), nil
+		return handleWorkerInitRequest(content.WorkerInitRequest, requestId), nil
 	case *pb.StreamingMessage_FunctionsMetadataRequest:
 		log.Println("Handling FunctionsMetadataRequest")
-		return handleFunctionsMetadataRequest(content.FunctionsMetadataRequest, disp.App), nil
+		return handleFunctionsMetadataRequest(content.FunctionsMetadataRequest, disp.App, requestId), nil
 	case *pb.StreamingMessage_InvocationRequest:
 		log.Println("Handling InvocationRequest")
-		return handleInvocationRequest(content.InvocationRequest, disp, reqMsg.RequestId)
+		// For invocations, the Host *does* provide a specific RequestId that we MUST echo back exactly.
+		return handleInvocationRequest(content.InvocationRequest, disp, reqMsg.GetRequestId())
 	case *pb.StreamingMessage_FunctionLoadRequest:
 		log.Println("Handling FunctionLoadRequest")
-		return handleFunctionLoadRequest(content.FunctionLoadRequest, disp, reqMsg.RequestId), nil
+		return handleFunctionLoadRequest(content.FunctionLoadRequest, disp, requestId), nil
 	case *pb.StreamingMessage_WorkerStatusRequest:
 		log.Println("Handling WorkerStatusRequest")
-		return handleWorkerStatusRequest(reqMsg.RequestId, content.WorkerStatusRequest)
+		return handleWorkerStatusRequest(requestId, content.WorkerStatusRequest)
 	case *pb.StreamingMessage_WorkerTerminate:
 		log.Println("Handling WorkerTerminate")
-		return handleWorkerTerminate(reqMsg.RequestId, content.WorkerTerminate)
+		return handleWorkerTerminate(requestId, content.WorkerTerminate)
 	case *pb.StreamingMessage_FunctionEnvironmentReloadRequest:
 		log.Println("Handling FunctionEnvironmentReloadRequest")
-		return handleFunctionEnvironmentReloadRequest(reqMsg.RequestId, content.FunctionEnvironmentReloadRequest)
+		return handleFunctionEnvironmentReloadRequest(requestId, content.FunctionEnvironmentReloadRequest)
 	default:
 		log.Printf("Received unhandled message type: %T\n", content)
 		return nil, nil

--- a/worker/handlers.go
+++ b/worker/handlers.go
@@ -33,8 +33,8 @@ func handleWorkerInitRequest(req *pb.WorkerInitRequest, requestId string) *pb.St
 	}
 }
 
-func handleFunctionsMetadataRequest(req *pb.FunctionsMetadataRequest, app *sdk.App) *pb.StreamingMessage {
-	log.Printf("Received FunctionsMetadataRequest")
+func handleFunctionsMetadataRequest(req *pb.FunctionsMetadataRequest, app *sdk.App, requestId string) *pb.StreamingMessage {
+	log.Printf("Received FunctionsMetadataRequest: RequestId=%s", requestId)
 	var functions []*pb.RpcFunctionMetadata
 	app.RegisteredFunctions.Range(func(key, value interface{}) bool {
 		rf := value.(*sdk.RegisteredFunction)
@@ -108,7 +108,7 @@ func handleFunctionsMetadataRequest(req *pb.FunctionsMetadataRequest, app *sdk.A
 	})
 
 	return &pb.StreamingMessage{
-		RequestId: "",
+		RequestId: requestId,
 		Content: &pb.StreamingMessage_FunctionMetadataResponse{
 			FunctionMetadataResponse: &pb.FunctionMetadataResponse{
 				FunctionMetadataResults: functions,


### PR DESCRIPTION
This PR fixes an issue where the request_id was missing (empty) in the worker's internal logging and gRPC responses, specifically during the worker initialization phase.

Root Cause:
The Azure Functions Host does not populate the request_id property on the StreamingMessage gRPC envelopes for internal lifecycle events (such as WorkerInitRequest or FunctionsMetadataRequest).

Resolution:
Use the request id from the worker startup args