### PR TITLE
Add missing input/output binding methods to all builders and close test gaps

### DIFF
--- a/sdk/app.go
+++ b/sdk/app.go
@@ -135,6 +135,17 @@ func (b *HttpFunctionBuilder) ServiceBusTopicOutput(name, topicName, connection 
 	return b
 }
 
+// EventGridOutput adds an EventGrid output binding.
+func (b *HttpFunctionBuilder) EventGridOutput(name, topicEndpointUri, topicKeySetting string) *HttpFunctionBuilder {
+	output := &bindings.EventGridOutput{
+		Name:             name,
+		TopicEndpointUri: topicEndpointUri,
+		TopicKeySetting:  topicKeySetting,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, output.ToBinding())
+	return b
+}
+
 // CosmosFunctionBuilder is a builder for creating CosmosDB triggered functions.
 type CosmosFunctionBuilder struct {
 	trigger *bindings.CosmosDB
@@ -247,6 +258,28 @@ func (b *BlobFunctionBuilder) ServiceBusTopicOutput(name, topicName, connection 
 	return b
 }
 
+// BlobInput adds a blob input binding.
+func (b *BlobFunctionBuilder) BlobInput(name, path, connection string) *BlobFunctionBuilder {
+	blobInput := &bindings.BlobInput{
+		Name:       name,
+		Path:       path,
+		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, blobInput.ToBinding())
+	return b
+}
+
+// EventGridOutput adds an EventGrid output binding.
+func (b *BlobFunctionBuilder) EventGridOutput(name, topicEndpointUri, topicKeySetting string) *BlobFunctionBuilder {
+	output := &bindings.EventGridOutput{
+		Name:             name,
+		TopicEndpointUri: topicEndpointUri,
+		TopicKeySetting:  topicKeySetting,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, output.ToBinding())
+	return b
+}
+
 func (b *BlobFunctionBuilder) updateBinding() {
 	if len(b.rf.RawBindings) > 0 {
 		newBinding := b.trigger.ToBinding()
@@ -296,6 +329,39 @@ func (b *CosmosFunctionBuilder) ServiceBusTopicOutput(name, topicName, connectio
 		Name:      name,
 		TopicName: topicName,
 		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, output.ToBinding())
+	return b
+}
+
+// BlobInput adds a blob input binding.
+func (b *CosmosFunctionBuilder) BlobInput(name, path, connection string) *CosmosFunctionBuilder {
+	blobInput := &bindings.BlobInput{
+		Name:       name,
+		Path:       path,
+		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, blobInput.ToBinding())
+	return b
+}
+
+// BlobOutput adds a blob output binding.
+func (b *CosmosFunctionBuilder) BlobOutput(name, path, connection string) *CosmosFunctionBuilder {
+	blobOutput := &bindings.BlobOutput{
+		Name:       name,
+		Path:       path,
+		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, blobOutput.ToBinding())
+	return b
+}
+
+// EventGridOutput adds an EventGrid output binding.
+func (b *CosmosFunctionBuilder) EventGridOutput(name, topicEndpointUri, topicKeySetting string) *CosmosFunctionBuilder {
+	output := &bindings.EventGridOutput{
+		Name:             name,
+		TopicEndpointUri: topicEndpointUri,
+		TopicKeySetting:  topicKeySetting,
 	}
 	b.rf.RawBindings = append(b.rf.RawBindings, output.ToBinding())
 	return b
@@ -365,6 +431,28 @@ func (b *EventGridFunctionBuilder) ServiceBusTopicOutput(name, topicName, connec
 	return b
 }
 
+// BlobInput adds a blob input binding.
+func (b *EventGridFunctionBuilder) BlobInput(name, path, connection string) *EventGridFunctionBuilder {
+	blobInput := &bindings.BlobInput{
+		Name:       name,
+		Path:       path,
+		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, blobInput.ToBinding())
+	return b
+}
+
+// BlobOutput adds a blob output binding.
+func (b *EventGridFunctionBuilder) BlobOutput(name, path, connection string) *EventGridFunctionBuilder {
+	blobOutput := &bindings.BlobOutput{
+		Name:       name,
+		Path:       path,
+		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, blobOutput.ToBinding())
+	return b
+}
+
 // TimerFunctionBuilder provides a fluent API for configuring timer-triggered functions.
 type TimerFunctionBuilder struct {
 	trigger *bindings.TimerTrigger
@@ -420,6 +508,50 @@ func (b *TimerFunctionBuilder) ServiceBusTopicOutput(name, topicName, connection
 		Name:      name,
 		TopicName: topicName,
 		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, output.ToBinding())
+	return b
+}
+
+// BlobInput adds a blob input binding.
+func (b *TimerFunctionBuilder) BlobInput(name, path, connection string) *TimerFunctionBuilder {
+	blobInput := &bindings.BlobInput{
+		Name:       name,
+		Path:       path,
+		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, blobInput.ToBinding())
+	return b
+}
+
+// BlobOutput adds a blob output binding.
+func (b *TimerFunctionBuilder) BlobOutput(name, path, connection string) *TimerFunctionBuilder {
+	blobOutput := &bindings.BlobOutput{
+		Name:       name,
+		Path:       path,
+		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, blobOutput.ToBinding())
+	return b
+}
+
+// EventHubOutput adds an EventHub output binding.
+func (b *TimerFunctionBuilder) EventHubOutput(name, eventHubName, connection string) *TimerFunctionBuilder {
+	output := &bindings.EventHubOutput{
+		Name:         name,
+		EventHubName: eventHubName,
+		Connection:   connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, output.ToBinding())
+	return b
+}
+
+// EventGridOutput adds an EventGrid output binding.
+func (b *TimerFunctionBuilder) EventGridOutput(name, topicEndpointUri, topicKeySetting string) *TimerFunctionBuilder {
+	output := &bindings.EventGridOutput{
+		Name:             name,
+		TopicEndpointUri: topicEndpointUri,
+		TopicKeySetting:  topicKeySetting,
 	}
 	b.rf.RawBindings = append(b.rf.RawBindings, output.ToBinding())
 	return b
@@ -503,6 +635,39 @@ func (b *EventHubFunctionBuilder) ServiceBusTopicOutput(name, topicName, connect
 		Name:      name,
 		TopicName: topicName,
 		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, output.ToBinding())
+	return b
+}
+
+// BlobInput adds a blob input binding.
+func (b *EventHubFunctionBuilder) BlobInput(name, path, connection string) *EventHubFunctionBuilder {
+	blobInput := &bindings.BlobInput{
+		Name:       name,
+		Path:       path,
+		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, blobInput.ToBinding())
+	return b
+}
+
+// BlobOutput adds a blob output binding.
+func (b *EventHubFunctionBuilder) BlobOutput(name, path, connection string) *EventHubFunctionBuilder {
+	blobOutput := &bindings.BlobOutput{
+		Name:       name,
+		Path:       path,
+		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, blobOutput.ToBinding())
+	return b
+}
+
+// EventGridOutput adds an EventGrid output binding.
+func (b *EventHubFunctionBuilder) EventGridOutput(name, topicEndpointUri, topicKeySetting string) *EventHubFunctionBuilder {
+	output := &bindings.EventGridOutput{
+		Name:             name,
+		TopicEndpointUri: topicEndpointUri,
+		TopicKeySetting:  topicKeySetting,
 	}
 	b.rf.RawBindings = append(b.rf.RawBindings, output.ToBinding())
 	return b
@@ -592,6 +757,39 @@ func (b *ServiceBusQueueFunctionBuilder) EventHubOutput(name, eventHubName, conn
 		Name:         name,
 		EventHubName: eventHubName,
 		Connection:   connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, output.ToBinding())
+	return b
+}
+
+// BlobInput adds a blob input binding.
+func (b *ServiceBusQueueFunctionBuilder) BlobInput(name, path, connection string) *ServiceBusQueueFunctionBuilder {
+	blobInput := &bindings.BlobInput{
+		Name:       name,
+		Path:       path,
+		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, blobInput.ToBinding())
+	return b
+}
+
+// BlobOutput adds a blob output binding.
+func (b *ServiceBusQueueFunctionBuilder) BlobOutput(name, path, connection string) *ServiceBusQueueFunctionBuilder {
+	blobOutput := &bindings.BlobOutput{
+		Name:       name,
+		Path:       path,
+		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, blobOutput.ToBinding())
+	return b
+}
+
+// EventGridOutput adds an EventGrid output binding.
+func (b *ServiceBusQueueFunctionBuilder) EventGridOutput(name, topicEndpointUri, topicKeySetting string) *ServiceBusQueueFunctionBuilder {
+	output := &bindings.EventGridOutput{
+		Name:             name,
+		TopicEndpointUri: topicEndpointUri,
+		TopicKeySetting:  topicKeySetting,
 	}
 	b.rf.RawBindings = append(b.rf.RawBindings, output.ToBinding())
 	return b
@@ -688,6 +886,39 @@ func (b *ServiceBusTopicFunctionBuilder) EventHubOutput(name, eventHubName, conn
 		Name:         name,
 		EventHubName: eventHubName,
 		Connection:   connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, output.ToBinding())
+	return b
+}
+
+// BlobInput adds a blob input binding.
+func (b *ServiceBusTopicFunctionBuilder) BlobInput(name, path, connection string) *ServiceBusTopicFunctionBuilder {
+	blobInput := &bindings.BlobInput{
+		Name:       name,
+		Path:       path,
+		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, blobInput.ToBinding())
+	return b
+}
+
+// BlobOutput adds a blob output binding.
+func (b *ServiceBusTopicFunctionBuilder) BlobOutput(name, path, connection string) *ServiceBusTopicFunctionBuilder {
+	blobOutput := &bindings.BlobOutput{
+		Name:       name,
+		Path:       path,
+		Connection: connection,
+	}
+	b.rf.RawBindings = append(b.rf.RawBindings, blobOutput.ToBinding())
+	return b
+}
+
+// EventGridOutput adds an EventGrid output binding.
+func (b *ServiceBusTopicFunctionBuilder) EventGridOutput(name, topicEndpointUri, topicKeySetting string) *ServiceBusTopicFunctionBuilder {
+	output := &bindings.EventGridOutput{
+		Name:             name,
+		TopicEndpointUri: topicEndpointUri,
+		TopicKeySetting:  topicKeySetting,
 	}
 	b.rf.RawBindings = append(b.rf.RawBindings, output.ToBinding())
 	return b

--- a/sdk/app_test.go
+++ b/sdk/app_test.go
@@ -333,6 +333,155 @@ func TestEventGrid_WithOutput(t *testing.T) {
 
 // --- ServiceBus Queue builder tests ---
 
+func TestTimer_BasicRegistration(t *testing.T) {
+	app := FunctionApp()
+	handler := func() {}
+
+	builder := app.Timer("timerFunc", handler)
+	if builder == nil {
+		t.Fatal("expected non-nil builder")
+	}
+
+	app.RegisteredFunctions.Range(func(key, value interface{}) bool {
+		rf := value.(*RegisteredFunction)
+		if rf.RawBindings[0].Type != "timerTrigger" {
+			t.Errorf("expected type %q, got %q", "timerTrigger", rf.RawBindings[0].Type)
+		}
+		return true
+	})
+}
+
+func TestTimer_Chaining(t *testing.T) {
+	app := FunctionApp()
+	handler := func() {}
+
+	app.Timer("timerFull", handler).
+		Schedule("0 */5 * * * *")
+
+	app.RegisteredFunctions.Range(func(key, value interface{}) bool {
+		rf := value.(*RegisteredFunction)
+		binding := rf.RawBindings[0]
+		if binding.TimerBinding == nil {
+			t.Fatal("expected TimerBinding")
+		}
+		if binding.TimerBinding.Schedule != "0 */5 * * * *" {
+			t.Errorf("expected schedule %q, got %q", "0 */5 * * * *", binding.TimerBinding.Schedule)
+		}
+		return true
+	})
+}
+
+// --- EventHub builder tests ---
+
+func TestEventHub_BasicRegistration(t *testing.T) {
+	app := FunctionApp()
+	handler := func(msg string) {}
+
+	builder := app.EventHub("ehFunc", handler)
+	if builder == nil {
+		t.Fatal("expected non-nil builder")
+	}
+
+	app.RegisteredFunctions.Range(func(key, value interface{}) bool {
+		rf := value.(*RegisteredFunction)
+		if rf.RawBindings[0].Type != "eventHubTrigger" {
+			t.Errorf("expected type %q, got %q", "eventHubTrigger", rf.RawBindings[0].Type)
+		}
+		return true
+	})
+}
+
+func TestEventHub_Chaining(t *testing.T) {
+	app := FunctionApp()
+	handler := func(msg string) {}
+
+	app.EventHub("ehFull", handler).
+		EventHubName("myeventhub").
+		Connection("EventHubConnection").
+		ConsumerGroup("myGroup").
+		Cardinality("many")
+
+	app.RegisteredFunctions.Range(func(key, value interface{}) bool {
+		rf := value.(*RegisteredFunction)
+		binding := rf.RawBindings[0]
+		if binding.EventHubBinding == nil {
+			t.Fatal("expected EventHubBinding")
+		}
+		if binding.EventHubBinding.EventHubName != "myeventhub" {
+			t.Errorf("expected eventHubName %q, got %q", "myeventhub", binding.EventHubBinding.EventHubName)
+		}
+		if binding.EventHubBinding.Connection != "EventHubConnection" {
+			t.Errorf("expected connection %q, got %q", "EventHubConnection", binding.EventHubBinding.Connection)
+		}
+		if binding.EventHubBinding.ConsumerGroup != "myGroup" {
+			t.Errorf("expected consumerGroup %q, got %q", "myGroup", binding.EventHubBinding.ConsumerGroup)
+		}
+		if binding.EventHubBinding.Cardinality != "many" {
+			t.Errorf("expected cardinality %q, got %q", "many", binding.EventHubBinding.Cardinality)
+		}
+		return true
+	})
+}
+
+func TestEventHub_WithOutput(t *testing.T) {
+	app := FunctionApp()
+	handler := func(msg string) {}
+
+	app.EventHub("ehWithOutput", handler).
+		EventHubName("inputhub").
+		Connection("EventHubConnection").
+		EventHubOutput("outputMsg", "outputhub", "EventHubConnection")
+
+	app.RegisteredFunctions.Range(func(key, value interface{}) bool {
+		rf := value.(*RegisteredFunction)
+		if len(rf.RawBindings) != 2 {
+			t.Errorf("expected 2 bindings, got %d", len(rf.RawBindings))
+		}
+		outBinding := rf.RawBindings[1]
+		if outBinding.Name != "outputMsg" {
+			t.Errorf("expected output binding name %q, got %q", "outputMsg", outBinding.Name)
+		}
+		if outBinding.Type != "eventHub" {
+			t.Errorf("expected type %q, got %q", "eventHub", outBinding.Type)
+		}
+		if outBinding.Direction != "out" {
+			t.Errorf("expected direction %q, got %q", "out", outBinding.Direction)
+		}
+		return true
+	})
+}
+
+func TestCosmosDB_WithOutput(t *testing.T) {
+	app := FunctionApp()
+	handler := func(docs string) {}
+
+	app.CosmosDB("cosmosWithOutput", handler).
+		Database("mydb").
+		Container("mycontainer").
+		Connection("CosmosDBConnection").
+		EventHubOutput("outputMsg", "myeventhub", "EventHubConnection")
+
+	app.RegisteredFunctions.Range(func(key, value interface{}) bool {
+		rf := value.(*RegisteredFunction)
+		if len(rf.RawBindings) != 2 {
+			t.Errorf("expected 2 bindings, got %d", len(rf.RawBindings))
+		}
+		outBinding := rf.RawBindings[1]
+		if outBinding.Name != "outputMsg" {
+			t.Errorf("expected output binding name %q, got %q", "outputMsg", outBinding.Name)
+		}
+		if outBinding.Type != "eventHub" {
+			t.Errorf("expected type %q, got %q", "eventHub", outBinding.Type)
+		}
+		if outBinding.Direction != "out" {
+			t.Errorf("expected direction %q, got %q", "out", outBinding.Direction)
+		}
+		return true
+	})
+}
+
+// --- ServiceBus Queue builder tests ---
+
 func TestServiceBusQueue_BasicRegistration(t *testing.T) {
 	app := FunctionApp()
 	handler := func(msg string) {}
@@ -638,6 +787,8 @@ func TestMixedTriggerTypes(t *testing.T) {
 	app.Blob("blobFunc", func(data []byte) {}).Path("container/{name}")
 	app.EventGrid("eventFunc", func(event string) {})
 	app.ServiceBusQueue("sbFunc", func(msg string) {}).QueueName("myqueue").Connection("SBConn")
+	app.Timer("timerFunc", func() {}).Schedule("0 */5 * * * *")
+	app.EventHub("ehFunc", func(msg string) {}).EventHubName("myhub").Connection("EHConn")
 
 	count := 0
 	app.RegisteredFunctions.Range(func(key, value interface{}) bool {
@@ -645,8 +796,8 @@ func TestMixedTriggerTypes(t *testing.T) {
 		return true
 	})
 
-	if count != 5 {
-		t.Errorf("expected 5 registered functions, got %d", count)
+	if count != 7 {
+		t.Errorf("expected 7 registered functions, got %d", count)
 	}
 }
 


### PR DESCRIPTION
## Summary

Tech debt cleanup: ensure all trigger builders have all applicable input/output binding methods, and add missing test coverage for Timer and EventHub builders.

## Changes

### Missing binding methods added to \sdk/app.go\ (21 methods)

All 8 builders now support all 6 input/output binding types (48 methods total):

| Method | Added to builders |
|---|---|
| \EventGridOutput\ | HTTP, Cosmos, Blob, Timer, EventHub, SBQueue, SBTopic (7) |
| \BlobOutput\ | Cosmos, EventGrid, Timer, EventHub, SBQueue, SBTopic (6) |
| \BlobInput\ | Cosmos, Blob, EventGrid, Timer, EventHub, SBQueue, SBTopic (7) |
| \EventHubOutput\ | Timer (1) |

### Complete builder  binding matrix

| Builder | BlobInput | BlobOutput | EventHubOutput | EventGridOutput | SBQueueOutput | SBTopicOutput |
|---|---|---|---|---|---|---|
| HTTP |  |  |  |  new |  |  |
| CosmosDB |  new |  new |  |  new |  |  |
| Blob |  new |  |  |  new |  |  |
| EventGrid |  new |  new |  |  |  |  |
| Timer |  new |  new |  new |  new |  |  |
| EventHub |  new |  new |  |  new |  |  |
| SBQueue |  new |  new |  |  new |  |  |
| SBTopic |  new |  new |  |  new |  |  |

### Missing tests added to \sdk/app_test.go\ (7 tests)

- \TestTimer_BasicRegistration\  trigger type is \	imerTrigger\
- \TestTimer_Chaining\  \Schedule()\ sets schedule correctly
- \TestEventHub_BasicRegistration\  trigger type is \ventHubTrigger\
- \TestEventHub_Chaining\  \EventHubName()\, \Connection()\, \ConsumerGroup()\, \Cardinality()\
- \TestEventHub_WithOutput\  EventHub output binding on EventHub trigger
- \TestCosmosDB_WithOutput\  EventHub output binding on CosmosDB trigger
- \TestMixedTriggerTypes\ updated to cover all 7 trigger types (was 5)

## Testing

- All unit tests pass (\go test ./sdk/... ./worker/...\)
- \go vet\ clean
