### PR TITLE
Add NuGet release pipeline and worker.config.json profiles for flex consumption

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -1,0 +1,110 @@
+# ---------------------------------------------------------------
+# Azure DevOps Pipeline: Official Build & NuGet Package
+# Triggers on main (CI) and v* tags (release). Builds the Go
+# worker proxy, runs unit tests, and produces a NuGet package.
+# ---------------------------------------------------------------
+
+trigger:
+  batch: true
+  branches:
+    include:
+      - main
+  tags:
+    include:
+      - v*
+
+pr: none
+
+resources:
+  repositories:
+    - repository: 1es
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+    - repository: eng
+      type: git
+      name: engineering
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-windows-2022
+      os: windows
+    featureFlags:
+      golang:
+        internalModuleProxy:
+          enabled: true
+
+    sdl:
+      codeql:
+        compiled:
+          enabled: true
+        language: go
+
+    stages:
+      - stage: Build
+        displayName: 'Build & Package Artifacts'
+        jobs:
+          - template: /eng/ci/templates/jobs/build.yml@self
+            parameters:
+              PoolName: 1es-pool-azfunc
+              PublishArtifacts: true
+
+      - stage: UnitTests
+        displayName: 'Unit Tests'
+        dependsOn: []
+        jobs:
+          - template: /eng/ci/templates/jobs/unit-tests.yml@self
+            parameters:
+              PoolName: 1es-pool-azfunc
+
+      - stage: Package
+        displayName: 'NuGet Pack'
+        dependsOn: Build
+        jobs:
+          - job: PackageNuGet
+            displayName: 'Pack NuGet Package'
+            pool:
+              name: 1es-pool-azfunc
+              image: 1es-ubuntu-22.04
+              os: linux
+            templateContext:
+              outputParentDirectory: $(Build.ArtifactStagingDirectory)
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Build.ArtifactStagingDirectory)
+                  artifactName: NuGetPackage
+            steps:
+            - task: DownloadPipelineArtifact@2
+              displayName: 'Download Build Artifacts'
+              inputs:
+                buildType: current
+                artifactName: GolangWorker
+                targetPath: $(Pipeline.Workspace)/GolangWorker
+
+            - bash: |
+                # Determine version from git tag or generate CI version
+                if [[ "$(Build.SourceBranch)" == refs/tags/v* ]]; then
+                  TAG="$(Build.SourceBranchName)"
+                  VERSION="${TAG#v}"
+                  echo "Release build: version $VERSION"
+                else
+                  # CI build on main - use 0.0.0-ci.BuildNumber
+                  VERSION="0.0.0-ci.$(Build.BuildNumber)"
+                  echo "CI build: version $VERSION"
+                fi
+                echo "##vso[task.setvariable variable=WORKER_VERSION]$VERSION"
+              displayName: 'Set version from git tag'
+
+            - task: NuGetCommand@2
+              displayName: 'NuGet Pack'
+              inputs:
+                command: pack
+                packagesToPack: eng/pack/Microsoft.Azure.Functions.GolangWorker.nuspec
+                packDestination: $(Build.ArtifactStagingDirectory)
+                versioningScheme: byEnvVar
+                versionEnvVar: WORKER_VERSION
+                basePath: $(Pipeline.Workspace)/GolangWorker

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -48,6 +48,8 @@ extends:
         displayName: 'Build & Test'
         jobs:
           - template: /eng/ci/templates/jobs/build.yml@self
+            parameters:
+              PoolName: 1es-pool-azfunc-public
 
       - stage: UnitTests
         displayName: 'Unit Tests'

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -1,16 +1,34 @@
 # ---------------------------------------------------------------
 # Job Template: Build
 # Compiles the Go worker and runs go vet for static analysis.
+# Cross-compiles the proxy for linux/arm64. When PublishArtifacts
+# is true, stages artifacts for NuGet packaging.
 # ---------------------------------------------------------------
+
+parameters:
+  - name: PoolName
+    type: string
+    default: 1es-pool-azfunc-public
+  - name: PublishArtifacts
+    type: boolean
+    default: false
 
 jobs:
   - job: Build
     displayName: 'Build Go Worker'
 
     pool:
-      name: 1es-pool-azfunc-public
+      name: ${{ parameters.PoolName }}
       image: 1es-ubuntu-22.04
       os: linux
+
+    ${{ if parameters.PublishArtifacts }}:
+      templateContext:
+        outputParentDirectory: $(Build.ArtifactStagingDirectory)
+        outputs:
+          - output: pipelineArtifact
+            targetPath: $(Build.ArtifactStagingDirectory)
+            artifactName: GolangWorker
 
     steps:
     - task: GoTool@0
@@ -28,6 +46,14 @@ jobs:
       displayName: 'Run go vet'
 
     - script: |
-        go build -o bin/worker ./worker/...
-        go build -o bin/proxy ./proxy/...
+        go build ./worker/...
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
+          go build -ldflags -s -o bin/proxy ./proxy/...
       displayName: 'Run go build'
+
+    - ${{ if parameters.PublishArtifacts }}:
+      - script: |
+          mkdir -p $(Build.ArtifactStagingDirectory)/workers/golang
+          cp bin/proxy $(Build.ArtifactStagingDirectory)/workers/golang/
+          cp worker.config.json $(Build.ArtifactStagingDirectory)/workers/golang/
+        displayName: 'Stage artifacts'

--- a/eng/ci/worker-release.yml
+++ b/eng/ci/worker-release.yml
@@ -1,0 +1,183 @@
+# ---------------------------------------------------------------
+# Azure DevOps Pipeline: Worker Release
+# Manually triggered to publish the NuGet package to the internal
+# feed and create a PR to azure-functions-host.
+# ---------------------------------------------------------------
+
+pr: none
+trigger: none
+
+parameters:
+  - name: WorkerRelease
+    displayName: 'Publish NuGet & PR to Host'
+    type: boolean
+    default: false
+
+resources:
+  repositories:
+    - repository: 1es
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+    - repository: eng
+      type: git
+      name: engineering
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-windows-2022
+      os: windows
+
+    stages:
+      - stage: ReleaseGolangWorker
+        displayName: 'Release Golang Worker'
+        condition: eq(${{ parameters.WorkerRelease }}, True)
+        jobs:
+          - job: SetVersion
+            displayName: 'Determine Release Version'
+            pool:
+              name: 1es-pool-azfunc
+              image: 1es-ubuntu-22.04
+              os: linux
+            steps:
+            - bash: |
+                # Get version from the latest v* tag
+                TAG=$(git describe --tags --match "v*" --abbrev=0 2>/dev/null || echo "")
+                if [ -z "$TAG" ]; then
+                  echo "##vso[task.logissue type=error]No v* tag found."
+                  exit 1
+                fi
+                VERSION="${TAG#v}"
+                echo "Releasing version: $VERSION (tag: $TAG)"
+                echo "##vso[task.setvariable variable=NewWorkerVersion;isOutput=true]$VERSION"
+                echo "##vso[task.setvariable variable=ReleaseTag;isOutput=true]$TAG"
+              name: version
+              displayName: 'Get version from git tag'
+
+          - job: PublishNuget
+            displayName: 'Publish NuGet Package'
+            dependsOn: SetVersion
+            variables:
+              NewWorkerVersion: $[ dependencies.SetVersion.outputs['version.NewWorkerVersion'] ]
+            templateContext:
+              outputs:
+                - output: nuget
+                  packagesToPush: '$(Pipeline.Workspace)/NuGetPackage/**/*.nupkg;!$(Pipeline.Workspace)/NuGetPackage/**/*.symbols.nupkg'
+                  publishVstsFeed: 'e6a70c92-4128-439f-8012-382fe78d6396/eb652719-f36a-4e78-8541-e13a3cd655f9'
+                  allowPackageConflicts: true
+                  packageParentPath: '$(Pipeline.Workspace)'
+            steps:
+            - task: DownloadPipelineArtifact@2
+              displayName: 'Download NuGet Artifact from Official Build'
+              inputs:
+                buildType: specific
+                project: '3f99e810-c336-441f-8892-84983093ad7f'
+                definition: $(OfficialBuildDefinitionId)
+                specificBuildWithTriggering: true
+                buildVersionToDownload: latestFromBranch
+                branchName: 'refs/tags/v$(NewWorkerVersion)'
+                allowPartiallySucceededBuilds: true
+                targetPath: '$(Pipeline.Workspace)/NuGetPackage'
+                artifactName: NuGetPackage
+
+          - job: CheckNugetPackage
+            displayName: '(Manual) Verify NuGet Package'
+            dependsOn: PublishNuget
+            pool: server
+            steps:
+            - task: ManualValidation@1
+              displayName: 'Verify NuGet package contents'
+              inputs:
+                notifyUsers: ''
+                instructions: |
+                  Verify the published NuGet package at the internal feed.
+                  Ensure it contains workers/golang/proxy and workers/golang/worker.config.json.
+
+          - job: HostRepoPR
+            displayName: 'Create Host Repo PR'
+            dependsOn:
+              - CheckNugetPackage
+              - SetVersion
+            variables:
+              NewWorkerVersion: $[ dependencies.SetVersion.outputs['version.NewWorkerVersion'] ]
+            pool:
+              name: 1es-pool-azfunc
+              image: 1es-ubuntu-22.04
+              os: linux
+            steps:
+            - bash: |
+                GITHUB_TOKEN="$(GithubPat)"
+                VERSION="$(NewWorkerVersion)"
+                BRANCH="golang/$VERSION"
+
+                git config --global user.name "AzureFunctionsGolang"
+                git config --global user.email "azfunc@microsoft.com"
+
+                # Clone host repo
+                git clone "https://$GITHUB_TOKEN@github.com/Azure/azure-functions-host"
+                cd azure-functions-host
+                git checkout -b "$BRANCH" origin/dev
+
+                # Create or update Workers.Golang.props
+                cat > eng/build/Workers.Golang.props << EOF
+                <Project>
+
+                  <ItemGroup>
+                    <PackageReference Include="Microsoft.Azure.Functions.GolangWorker" VersionOverride="$VERSION" />
+                  </ItemGroup>
+
+                </Project>
+                EOF
+
+                # Update release notes
+                sed -i "s|-->|-->\n- Add Golang Worker Version [$VERSION](https://github.com/Azure/azure-functions-golang-worker/releases/tag/v$VERSION)|" release_notes.md
+
+                # Commit and push
+                git add eng/build/Workers.Golang.props release_notes.md
+                git commit -m "Add/Update Golang Worker Version to $VERSION"
+                git push origin "$BRANCH"
+
+                # Create PR
+                PR_BODY=$(cat <<'PRBODY'
+                ### Update Golang Worker
+
+                Add/Update Golang Worker to version $VERSION
+
+                Release: https://github.com/Azure/azure-functions-golang-worker/releases/tag/v$VERSION
+
+                ### Pull request checklist
+                * [x] My changes **do not** require documentation changes
+                * [x] I have added all required tests
+                PRBODY
+                )
+
+                curl -s -X POST \
+                  -H "Authorization: token $GITHUB_TOKEN" \
+                  -H "Content-Type: application/json" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  "https://api.github.com/repos/Azure/azure-functions-host/pulls" \
+                  -d "$(jq -n \
+                    --arg head "$BRANCH" \
+                    --arg base "dev" \
+                    --arg title "Add/Update Golang Worker Version to $VERSION" \
+                    --arg body "$PR_BODY" \
+                    '{head: $head, base: $base, title: $title, body: $body, draft: true}')"
+
+                echo "PR created for golang/$VERSION"
+              displayName: 'Create PR to azure-functions-host'
+
+          - job: CheckHostPR
+            displayName: '(Manual) Verify Host PR'
+            dependsOn: HostRepoPR
+            pool: server
+            steps:
+            - task: ManualValidation@1
+              displayName: 'Finish Host PR'
+              inputs:
+                notifyUsers: ''
+                instructions: |
+                  Go to https://github.com/Azure/azure-functions-host/pulls and review/merge the Golang Worker PR.

--- a/eng/pack/Microsoft.Azure.Functions.GolangWorker.nuspec
+++ b/eng/pack/Microsoft.Azure.Functions.GolangWorker.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Azure.Functions.GolangWorker</id>
+    <version>0.1.0</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Microsoft Azure Functions Golang Worker</description>
+    <copyright>© .NET Foundation. All rights reserved.</copyright>
+    <contentFiles>
+      <files include="**/*" buildAction="None" copyToOutput="true" flatten="false" />
+    </contentFiles>
+  </metadata>
+  <files>
+    <file src="workers\golang\worker.config.json" target="contentFiles\any\any\workers\golang\" />
+    <file src="workers\golang\proxy" target="contentFiles\any\any\workers\golang\" />
+  </files>
+</package>

--- a/worker.config.json
+++ b/worker.config.json
@@ -1,12 +1,26 @@
 {
     "description": {
         "language": "golang",
-        "supportedOperatingSystems":["LINUX", "OSX", "WINDOWS"],
-        "supportedArchitectures":["X64", "X86", "Arm64"],
-        "defaultExecutablePath": "app.exe",
+        "supportedOperatingSystems": ["LINUX"],
+        "supportedArchitectures": ["Arm64"],
+        "defaultExecutablePath": "app",
         "workerIndexing": "true"
-
     },
+    "profiles": [
+        {
+            "profileName": "FlexConsumption",
+            "conditions": [
+                {
+                    "conditionType": "environment",
+                    "conditionName": "WEBSITE_SKU",
+                    "conditionExpression": "(?i)^FlexConsumption$"
+                }
+            ],
+            "description": {
+                "defaultExecutablePath": "{workerDirectoryPath}/proxy"
+            }
+        }
+    ],
     "processOptions": {
         "initializationTimeout": "00:02:00",
         "environmentReloadTimeout": "00:02:00"


### PR DESCRIPTION
## Changes

- Add `worker.config.json` profiles to switch between `app` (dedicated) and `proxy` (flex consumption)
- Add `Microsoft.Azure.Functions.GolangWorker.nuspec` for NuGet packaging
- Add `official-build.yml` pipeline (triggers on main + v* tags)
- Add `worker-release.yml` pipeline (manual NuGet publish + host repo PR)
- Update `build.yml` template with cross-compile for linux/arm64 and artifact staging
- Update `public-build.yml` to pass PoolName parameter

## Related PRs
- azure-functions-host: ahmedmuhsin/add-golang-worker
- AAPT-Antares-Functions-Docker: ahmedmuhsin/add-golang-dockerfiles