### PR TITLE
Add golangci-lint to CI pipeline

### DIFF
--- a/eng/ci/.golangci.yml
+++ b/eng/ci/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   disable-all: true
   enable:
     - govet # Always keep the default govet enabled
+    - gofmt # Checks code is formatted with go fmt
     - revive # Checks variable/struct names
     - stylecheck # Checks Go style guide rules
     - tagliatelle # Checks struct tags

--- a/eng/ci/.golangci.yml
+++ b/eng/ci/.golangci.yml
@@ -1,0 +1,39 @@
+run:
+  timeout: 5m
+  
+linters:
+  disable-all: true
+  enable:
+    - govet # Always keep the default govet enabled
+    - revive # Checks variable/struct names
+    - stylecheck # Checks Go style guide rules
+    - tagliatelle # Checks struct tags
+
+output:
+  format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true
+
+linters-settings:
+  revive:
+    rules:
+      - name: var-naming
+        severity: warning
+        disabled: false
+        arguments:
+          # Allowed initialisms (adds to the default list like ID, HTTP, etc)
+          - - "VM"
+            - "API"
+
+  stylecheck:
+    # ST1003: Poorly chosen identifier (enforces Initialisms)
+    checks: ["all", "-ST1000"] # We disable ST1000 (missing package comment) to focus on naming
+
+  tagliatelle:
+    # Check the struct tag names
+    case:
+      rules:
+        # Enforce camelCase for json tags (e.g., json:"firstName")
+        json: camel
+        # Enforce snake_case for yaml tags (e.g., yaml:"first_name")
+        yaml: snake

--- a/eng/ci/templates/jobs/unit-tests.yml
+++ b/eng/ci/templates/jobs/unit-tests.yml
@@ -32,13 +32,6 @@ jobs:
         golangci-lint run --config=$(Build.SourcesDirectory)/eng/ci/.golangci.yml --out-format=colored-line-number ./... | tee $(Build.SourcesDirectory)/lint-results.txt || true
       displayName: 'Run golangci-lint'
 
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish lint report'
-      condition: always()
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/lint-results.txt'
-        ArtifactName: 'lint-report'
-
     - script: |
         export PATH=$PATH:$(go env GOPATH)/bin
         gotestsum --junitfile $(Build.SourcesDirectory)/test-results.xml -- -coverprofile=$(Build.SourcesDirectory)/coverage.out -covermode=atomic -coverpkg=./worker/...,./sdk/... ./worker/... ./sdk/...

--- a/eng/ci/templates/jobs/unit-tests.yml
+++ b/eng/ci/templates/jobs/unit-tests.yml
@@ -29,7 +29,8 @@ jobs:
 
     - script: |
         export PATH=$PATH:$(go env GOPATH)/bin
-        golangci-lint run --config=$(Build.SourcesDirectory)/eng/ci/.golangci.yml --out-format=colored-line-number,checkstyle:$(Build.SourcesDirectory)/lint-results.xml ./... || true
+        golangci-lint run --config=$(Build.SourcesDirectory)/eng/ci/.golangci.yml --out-format=colored-line-number ./... || true
+        golangci-lint run --config=$(Build.SourcesDirectory)/eng/ci/.golangci.yml --out-format=junit-xml ./... > $(Build.SourcesDirectory)/lint-results.xml 2>&1 || true
       displayName: 'Run golangci-lint'
 
     - task: PublishTestResults@2

--- a/eng/ci/templates/jobs/unit-tests.yml
+++ b/eng/ci/templates/jobs/unit-tests.yml
@@ -22,9 +22,16 @@ jobs:
       displayName: 'Download dependencies'
 
     - script: |
+        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
         go install gotest.tools/gotestsum@latest
         go install github.com/boumenot/gocover-cobertura@latest
       displayName: 'Install test tools'
+
+    - script: |
+        export PATH=$PATH:$(go env GOPATH)/bin
+        golangci-lint run --config=$(Build.SourcesDirectory)/eng/ci/.golangci.yml --out-format=colored-line-number ./...
+      displayName: 'Run golangci-lint'
+      continueOnError: true
 
     - script: |
         export PATH=$PATH:$(go env GOPATH)/bin

--- a/eng/ci/templates/jobs/unit-tests.yml
+++ b/eng/ci/templates/jobs/unit-tests.yml
@@ -29,20 +29,15 @@ jobs:
 
     - script: |
         export PATH=$PATH:$(go env GOPATH)/bin
-        golangci-lint run --config=$(Build.SourcesDirectory)/eng/ci/.golangci.yml --out-format=colored-line-number ./... || true
-        golangci-lint run --config=$(Build.SourcesDirectory)/eng/ci/.golangci.yml --out-format=junit-xml ./... > $(Build.SourcesDirectory)/lint-results.xml 2>&1 || true
+        golangci-lint run --config=$(Build.SourcesDirectory)/eng/ci/.golangci.yml --out-format=colored-line-number ./... | tee $(Build.SourcesDirectory)/lint-results.txt || true
       displayName: 'Run golangci-lint'
 
-    - task: PublishTestResults@2
-      displayName: 'Publish lint results'
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish lint report'
       condition: always()
       inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: '$(Build.SourcesDirectory)/lint-results.xml'
-        testRunTitle: 'golangci-lint'
-        mergeTestResults: false
-        failTaskOnFailedTests: false
-        failTaskOnMissingResultsFile: false
+        PathtoPublish: '$(Build.SourcesDirectory)/lint-results.txt'
+        ArtifactName: 'lint-report'
 
     - script: |
         export PATH=$PATH:$(go env GOPATH)/bin

--- a/eng/ci/templates/jobs/unit-tests.yml
+++ b/eng/ci/templates/jobs/unit-tests.yml
@@ -29,9 +29,19 @@ jobs:
 
     - script: |
         export PATH=$PATH:$(go env GOPATH)/bin
-        golangci-lint run --config=$(Build.SourcesDirectory)/eng/ci/.golangci.yml --out-format=colored-line-number ./...
+        golangci-lint run --config=$(Build.SourcesDirectory)/eng/ci/.golangci.yml --out-format=colored-line-number,checkstyle:$(Build.SourcesDirectory)/lint-results.xml ./... || true
       displayName: 'Run golangci-lint'
-      continueOnError: true
+
+    - task: PublishTestResults@2
+      displayName: 'Publish lint results'
+      condition: always()
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: '$(Build.SourcesDirectory)/lint-results.xml'
+        testRunTitle: 'golangci-lint'
+        mergeTestResults: false
+        failTaskOnFailedTests: false
+        failTaskOnMissingResultsFile: false
 
     - script: |
         export PATH=$PATH:$(go env GOPATH)/bin

--- a/eng/ci/templates/jobs/unit-tests.yml
+++ b/eng/ci/templates/jobs/unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
     - script: |
         export PATH=$PATH:$(go env GOPATH)/bin
-        golangci-lint run --config=$(Build.SourcesDirectory)/eng/ci/.golangci.yml --out-format=colored-line-number ./... | tee $(Build.SourcesDirectory)/lint-results.txt || true
+        golangci-lint run --config=$(Build.SourcesDirectory)/eng/ci/.golangci.yml --out-format=colored-line-number ./... || true
       displayName: 'Run golangci-lint'
 
     - script: |


### PR DESCRIPTION
## Summary
Integrates golangci-lint into the CI pipeline to surface code quality and style issues.

## Changes
- Added golangci-lint configuration at `eng/ci/.golangci.yml`
  - Enabled: govet, revive, stylecheck, tagliatelle
  - Configured var-naming rules for custom initialisms (VM, API)
  - Added CI-specific settings (timeout, output format)
- Integrated linting step into unit tests job template
  - Pinned to golangci-lint v1.62.2 for reproducibility
  - Runs early in pipeline (after dependency download, before tests)
  - It is currently configured surface issues without blocking builds

## Testing
- Validated .golangci.yml syntax
- Linting will run on next CI build without failing the pipeline
- Sample run: https://azfunc.visualstudio.com/public/_build/results?buildId=270100&view=logs&j=6b58850f-3858-5a05-33e2-5e41cbf03c4e&t=bddec1cf-ba37-5883-9c3e-fd1e8608f9a1

## Notes
Linting is informational only at this stage. Once stabilized, we can make it a blocking step.
