### PR TITLE
fix: proxy handles missing app binary gracefully during specialization

### DIFF
--- a/proxy/main.go
+++ b/proxy/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"path/filepath"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/azure/azure-functions-golang-worker/worker"
 	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
@@ -363,26 +365,40 @@ func (p *Proxy) specialize(req *pb.FunctionEnvironmentReloadRequest) {
 		cmd.Dir, _ = os.Getwd()
 	}
 
-	// Forward stdout/stderr for debugging
+	// Forward child stdout to proxy stdout so the host captures it.
+	// Capture child stderr in a buffer so we can log it explicitly
+	// before exiting if the child crashes. Without this, stderr output
+	// from a Go panic is lost because the proxy calls os.Exit() before
+	// the host finishes reading the stderr pipe.
 	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
 
 	log.Printf("Starting Child Worker: %s %v in %s", workerPath, args, cmd.Dir)
 	if err := cmd.Start(); err != nil {
 		log.Fatalf("Failed to start child worker: %v", err)
 	}
 
-	// Monitor child process: if the child dies, exit the proxy with the
-	// same exit code so the host detects it immediately via Process.Exited
+	// Monitor child process: if the child dies, log any captured stderr
+	// then exit with the same code so the host detects it via Process.Exited
 	// and restarts us (at which point the exec bypass kicks in).
 	go func() {
 		err := cmd.Wait()
 		if err != nil {
+			// Log captured stderr so it appears in FunctionAppLogs via the
+			// host's OnOutputDataReceived handler. This makes Go panic
+			// stack traces and error messages visible in App Insights.
+			if captured := stderrBuf.String(); len(captured) > 0 {
+				log.Printf("Child worker stderr output:\n%s", captured)
+			}
 			if exitErr, ok := err.(*exec.ExitError); ok {
 				log.Printf("Child process exited with code %d, propagating", exitErr.ExitCode())
+				// Give the host a moment to read our log output before we exit.
+				time.Sleep(100 * time.Millisecond)
 				os.Exit(exitErr.ExitCode())
 			}
 			log.Printf("Child process failed: %v, exiting", err)
+			time.Sleep(100 * time.Millisecond)
 			os.Exit(1)
 		}
 		log.Println("Child process exited cleanly, exiting proxy")

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -79,12 +79,14 @@ func main() {
 		log.Fatalf("exec failed: %v", err)
 	}
 
-	// The proxy only serves a purpose in flex consumption placeholder mode.
-	// If the app binary exists, the exec bypass above handles it.
-	// If we reach here without placeholder mode, it's a misconfiguration.
+	// If no app binary and not in placeholder mode, the container was
+	// specialized before the user deployed code (e.g. newly created app).
+	// Run as a lightweight no-op worker: respond to host messages with
+	// empty results so the host stays healthy until pods are recycled
+	// with deployed content.
 	if os.Getenv("WEBSITE_PLACEHOLDER_MODE") != "1" {
-		log.Fatalf("Proxy requires WEBSITE_PLACEHOLDER_MODE=1. "+
-			"App binary not found at %s and not in placeholder mode.", appPath)
+		log.Printf("No app binary at %s and not in placeholder mode. "+
+			"Running as no-op worker until pod is recycled with deployed content.", appPath)
 	}
 
 	// 1. Parse Args (same as Worker)
@@ -315,6 +317,29 @@ func (p *Proxy) specialize(req *pb.FunctionEnvironmentReloadRequest) {
 
 	// 2. Determine App Path
 	workerPath := appBinaryPath(dir)
+
+	// If the app binary doesn't exist yet, the container was specialized
+	// before the user deployed code (e.g. newly created function app).
+	// Respond to the FERR with success and stay alive as a no-op worker.
+	// The platform will recycle pods with deployed content later.
+	if _, err := os.Stat(workerPath); err != nil {
+		log.Printf("App binary not found at %s during specialization. "+
+			"Responding with success and running as no-op worker.", workerPath)
+		p.sendToHost(&pb.StreamingMessage{
+			RequestId: p.savedReloadRequestId,
+			Content: &pb.StreamingMessage_FunctionEnvironmentReloadResponse{
+				FunctionEnvironmentReloadResponse: &pb.FunctionEnvironmentReloadResponse{
+					Result: &pb.StatusResult{Status: pb.StatusResult_Success},
+				},
+			},
+		})
+		// Clear isSpecializing so subsequent messages (FunctionsMetadataRequest,
+		// heartbeats, etc.) are handled by the placeholder mode switch.
+		p.mutex.Lock()
+		p.isSpecializing = false
+		p.mutex.Unlock()
+		return
+	}
 
 	// 3. Construct Args
 	// Point the child to the proxy's local gRPC server, not the host.

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -42,6 +42,7 @@ type Proxy struct {
 	childStream    pb.FunctionRpc_EventStreamServer
 	childConnected chan struct{}
 	childInitDone  chan struct{}
+	noChildMode    chan struct{} // closed when specialize completes without starting a child
 
 	config   *worker.WorkerStartupConfig
 	server   *grpc.Server
@@ -106,6 +107,7 @@ func main() {
 		config:         config,
 		childConnected: make(chan struct{}),
 		childInitDone:  make(chan struct{}),
+		noChildMode:    make(chan struct{}),
 	}
 
 	// 2. Connect to Host
@@ -226,11 +228,17 @@ func (p *Proxy) handleHostMessage(msg *pb.StreamingMessage) {
 	// before any host messages (like FunctionsMetadataRequest) reach it.
 	if specializing {
 		log.Printf("Specializing - waiting for child init before forwarding: %T", msg.Content)
-		<-p.childInitDone
-		if err := p.childStream.Send(msg); err != nil {
-			log.Printf("Error forwarding to child during specialization: %v", err)
+		select {
+		case <-p.childInitDone:
+			// Child started and initialized — forward to child
+			if err := p.childStream.Send(msg); err != nil {
+				log.Printf("Error forwarding to child during specialization: %v", err)
+			}
+			return
+		case <-p.noChildMode:
+			// No binary or not executable — fall through to placeholder switch
+			log.Printf("No child started during specialization, handling as placeholder: %T", msg.Content)
 		}
-		return
 	}
 
 	// Placeholder Mode Logic
@@ -340,8 +348,7 @@ func (p *Proxy) specialize(req *pb.FunctionEnvironmentReloadRequest) {
 				},
 			},
 		})
-		// Clear isSpecializing so subsequent messages (FunctionsMetadataRequest,
-		// heartbeats, etc.) are handled by the placeholder mode switch.
+		close(p.noChildMode)
 		p.mutex.Lock()
 		p.isSpecializing = false
 		p.mutex.Unlock()
@@ -361,6 +368,7 @@ func (p *Proxy) specialize(req *pb.FunctionEnvironmentReloadRequest) {
 				},
 			},
 		})
+		close(p.noChildMode)
 		p.mutex.Lock()
 		p.isSpecializing = false
 		p.mutex.Unlock()

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -74,7 +74,12 @@ func main() {
 	// (since defaultExecutablePath points here). Instead of running as a proxy,
 	// we replace ourselves with the real app. Zero overhead.
 	appPath := appBinaryPath(defaultAppDir)
-	if _, err := os.Stat(appPath); err == nil {
+	if info, err := os.Stat(appPath); err == nil {
+		// Check executable permission before attempting exec.
+		if info.Mode()&0111 == 0 {
+			log.Fatalf("App binary at %s is not executable (mode %s). "+
+				"Ensure the binary has execute permissions (chmod +x).", appPath, info.Mode())
+		}
 		log.Printf("Real app found at %s, exec into it", appPath)
 		args := append([]string{appPath}, os.Args[1:]...)
 		err := syscall.Exec(appPath, args, os.Environ())
@@ -324,7 +329,7 @@ func (p *Proxy) specialize(req *pb.FunctionEnvironmentReloadRequest) {
 	// before the user deployed code (e.g. newly created function app).
 	// Respond to the FERR with success and stay alive as a no-op worker.
 	// The platform will recycle pods with deployed content later.
-	if _, err := os.Stat(workerPath); err != nil {
+	if info, err := os.Stat(workerPath); err != nil {
 		log.Printf("App binary not found at %s during specialization. "+
 			"Responding with success and running as no-op worker.", workerPath)
 		p.sendToHost(&pb.StreamingMessage{
@@ -337,6 +342,25 @@ func (p *Proxy) specialize(req *pb.FunctionEnvironmentReloadRequest) {
 		})
 		// Clear isSpecializing so subsequent messages (FunctionsMetadataRequest,
 		// heartbeats, etc.) are handled by the placeholder mode switch.
+		p.mutex.Lock()
+		p.isSpecializing = false
+		p.mutex.Unlock()
+		return
+	} else if info.Mode()&0111 == 0 {
+		errMsg := fmt.Sprintf("App binary at %s is not executable (mode %s). "+
+			"Ensure the binary has execute permissions (chmod +x).", workerPath, info.Mode())
+		log.Print(errMsg)
+		p.sendToHost(&pb.StreamingMessage{
+			RequestId: p.savedReloadRequestId,
+			Content: &pb.StreamingMessage_FunctionEnvironmentReloadResponse{
+				FunctionEnvironmentReloadResponse: &pb.FunctionEnvironmentReloadResponse{
+					Result: &pb.StatusResult{
+						Status:    pb.StatusResult_Failure,
+						Exception: &pb.RpcException{Message: errMsg},
+					},
+				},
+			},
+		})
 		p.mutex.Lock()
 		p.isSpecializing = false
 		p.mutex.Unlock()

--- a/tests/consumption/Dockerfile.flex-test-specialize-before-deploy
+++ b/tests/consumption/Dockerfile.flex-test-specialize-before-deploy
@@ -1,0 +1,25 @@
+# Tests the production flow where the proxy starts post-specialization
+# without an app binary deployed.
+# Uses the MCR native1.0 image as base but replaces the proxy with a local build
+# so we can test proxy changes against the real host image.
+FROM golang:1.24 AS proxy-builder
+WORKDIR /src
+COPY go.mod go.sum ./
+COPY sdk/ sdk/
+COPY worker/ worker/
+COPY proxy/ proxy/
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /proxy ./proxy/
+
+FROM mcr.microsoft.com/azure-functions/noble/flexconsumption:4.1049.100-1-native1.0 AS runtime
+
+# Replace the released proxy with the locally-built one
+COPY --from=proxy-builder /proxy /azure-functions-host/workers/native/proxy
+RUN chmod +x /azure-functions-host/workers/native/proxy
+
+ENV AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+
+# Install unzip for runtime app deployment
+RUN apt-get update && apt-get install -y -qq unzip
+
+# No app pre-baked — the test reproduces the case where the container is
+# already specialized but no app binary has been deployed yet.

--- a/tests/consumption/consumption_helpers_test.go
+++ b/tests/consumption/consumption_helpers_test.go
@@ -55,6 +55,18 @@ func requireDocker(t testing.TB) {
 // buildAndStartFlex builds a Docker image from the given Dockerfile name and
 // starts a flex consumption container in placeholder mode.
 func buildAndStartFlex(t testing.TB, dockerfileName, imageName string) *flexContainer {
+	return buildAndStartFlexWithOpts(t, dockerfileName, imageName, true, nil)
+}
+
+// buildAndStartFlexSpecialized builds and starts a container that is already
+// past specialization (WEBSITE_PLACEHOLDER_MODE=0). This matches the production
+// scenario where the host restarts after a previous specialization.
+func buildAndStartFlexSpecialized(t testing.TB, dockerfileName, imageName string, extraEnv map[string]string) *flexContainer {
+	return buildAndStartFlexWithOpts(t, dockerfileName, imageName, false, extraEnv)
+}
+
+// buildAndStartFlexWithOpts is the shared implementation for starting containers.
+func buildAndStartFlexWithOpts(t testing.TB, dockerfileName, imageName string, placeholderMode bool, extraEnv map[string]string) *flexContainer {
 	t.Helper()
 
 	dockerfile := filepath.Join(repoRoot(), "tests", "consumption", dockerfileName)
@@ -73,12 +85,19 @@ func buildAndStartFlex(t testing.TB, dockerfileName, imageName string) *flexCont
 		"--cap-add", "SYS_ADMIN",
 		"--device", "/dev/fuse",
 		"-e", fmt.Sprintf("CONTAINER_ENCRYPTION_KEY=%s", dummyContKey),
-		"-e", "WEBSITE_PLACEHOLDER_MODE=1",
 		"-e", fmt.Sprintf("WEBSITE_SITE_NAME=%s", id),
 		"-e", fmt.Sprintf("WEBSITE_POD_NAME=%s", id),
 		"-e", "WEBSITE_SKU=FlexConsumption",
-		imageName,
 	}
+	if placeholderMode {
+		args = append(args, "-e", "WEBSITE_PLACEHOLDER_MODE=1")
+	} else {
+		args = append(args, "-e", "WEBSITE_PLACEHOLDER_MODE=0")
+	}
+	for k, v := range extraEnv {
+		args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
+	}
+	args = append(args, imageName)
 
 	out, err = exec.Command("docker", args...).CombinedOutput()
 	if err != nil {
@@ -139,6 +158,23 @@ func (fc *flexContainer) killWorkerProcess() {
 	// death and exits, or killing the proxy directly kills both.
 	// On restart, the proxy finds /home/site/wwwroot/app and execs into it.
 	exec.Command("docker", "exec", fc.id, "pkill", "-9", "-f", "workers/native/proxy").Run()
+}
+
+// restartHost calls POST /admin/host/restart to trigger a script host rebuild.
+// This causes the host to create new worker channels, which in turn starts
+// a new proxy process that can pick up a newly deployed app binary.
+func (fc *flexContainer) restartHost() {
+	fc.t.Helper()
+	req, _ := http.NewRequest("POST", fc.url()+"/admin/host/restart", nil)
+	fc.addAuthHeaders(req)
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		fc.t.Logf("restart request failed (may be expected if host is rebuilding): %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	fc.t.Logf("restart returned %d", resp.StatusCode)
 }
 
 // deployApp extracts a zip and copies its contents into /home/site/wwwroot/.
@@ -208,10 +244,16 @@ func (fc *flexContainer) specialize(env map[string]string) {
 
 // sendRequest sends an HTTP request with auth headers, retrying until 200.
 func (fc *flexContainer) sendRequest(method, path string) (int, []byte) {
+	return fc.sendRequestWithTimeout(method, path, 60*time.Second)
+}
+
+// sendRequestWithTimeout sends an HTTP request with auth headers, retrying
+// until 200 or the given timeout expires.
+func (fc *flexContainer) sendRequestWithTimeout(method, path string, timeout time.Duration) (int, []byte) {
 	fc.t.Helper()
 	client := &http.Client{Timeout: 10 * time.Second}
 
-	deadline := time.Now().Add(60 * time.Second)
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		req, _ := http.NewRequest(method, fc.url()+path, nil)
 		fc.addAuthHeaders(req)
@@ -227,7 +269,7 @@ func (fc *flexContainer) sendRequest(method, path string) (int, []byte) {
 		}
 		time.Sleep(2 * time.Second)
 	}
-	fc.t.Fatalf("request %s %s did not return 200 within timeout\nlogs:\n%s", method, path, fc.logs())
+	fc.t.Fatalf("request %s %s did not return 200 within %v\nlogs:\n%s", method, path, timeout, fc.logs())
 	return 0, nil
 }
 

--- a/tests/consumption/consumption_helpers_test.go
+++ b/tests/consumption/consumption_helpers_test.go
@@ -177,6 +177,25 @@ func (fc *flexContainer) restartHost() {
 	fc.t.Logf("restart returned %d", resp.StatusCode)
 }
 
+// restartContainer does a docker restart, simulating a pod recycle.
+// The container filesystem state (deployed binaries) is preserved, but
+// all processes restart fresh. The port mapping is preserved.
+func (fc *flexContainer) restartContainer() {
+	fc.t.Helper()
+	out, err := exec.Command("docker", "restart", fc.id).CombinedOutput()
+	if err != nil {
+		fc.t.Fatalf("docker restart failed: %v\n%s", err, out)
+	}
+	// Re-read the port in case it changed (shouldn't with docker restart, but safe)
+	time.Sleep(3 * time.Second)
+	portOut, err := exec.Command("docker", "port", fc.id).CombinedOutput()
+	if err != nil {
+		fc.t.Fatalf("failed to get port after restart: %v\n%s", err, portOut)
+	}
+	parts := strings.Split(strings.TrimSpace(string(portOut)), ":")
+	fc.port = parts[len(parts)-1]
+}
+
 // deployApp extracts a zip and copies its contents into /home/site/wwwroot/.
 func (fc *flexContainer) deployApp(zipPath string) {
 	fc.t.Helper()

--- a/tests/consumption/specialize_before_deploy_test.go
+++ b/tests/consumption/specialize_before_deploy_test.go
@@ -107,20 +107,17 @@ func TestSpecializeBeforeDeploy(t *testing.T) {
 //     Host is specialized, healthy, zero functions. Container stays alive.
 //  3. User deploys code via `func azure functionapp publish` or ARM
 //  4. Kudu uploads package → platform kills all worker pods (removeworker/allStandard)
-//  5. New container starts fresh → specialization → binary exists from FUSE mount
+//  5. New pod starts fresh → specialization → binary exists from FUSE mount
 //  6. /api/hello returns 200
 //
-// This test covers steps 1-2, then verifies the container is healthy.
-// Steps 3-6 are effectively covered by existing tests (e.g. consumption_test.go)
-// that test normal specialization with a pre-baked app.
-//
-// Before the fix, step 2 would crash the proxy (log.Fatalf in specialize()),
-// making the container unhealthy. The platform would find an unhealthy pod
-// and the user would see errors.
+// We simulate the pod recycle (step 4-5) with docker restart: the container
+// filesystem state (deployed binary) is preserved, but all processes restart
+// fresh — just like a new pod with content already mounted.
 func TestSpecializeBeforeDeployFullFlow(t *testing.T) {
 	requireDocker(t)
 
 	connStr := azuriteConnString(t)
+	zipPath := buildSampleZipMinimal(t, "httpTrigger")
 
 	// Start in placeholder mode with no app pre-baked.
 	fc := buildAndStartFlex(t,
@@ -128,48 +125,54 @@ func TestSpecializeBeforeDeployFullFlow(t *testing.T) {
 		"goworker-specialize-before-deploy-full:latest")
 	fc.waitForPing(90 * time.Second)
 
-	// Specialize with a real Azurite connection but no app deployed yet.
-	// With the fix, the proxy responds to FERR with success and returns
-	// empty functions metadata — the host proceeds normally.
-	t.Log("Specializing without app deployed...")
+	// --- Phase 1: Specialize without binary ---
+	t.Log("Phase 1: Specializing without app deployed...")
 	fc.specialize(map[string]string{
 		"AzureWebJobsStorage": connStr,
 	})
 
-	// Give the host time to complete specialization.
-	time.Sleep(30 * time.Second)
+	time.Sleep(15 * time.Second)
 
-	// Verify container is still running and healthy (proxy didn't crash-loop).
+	// Verify container is healthy (proxy didn't crash-loop).
 	out, err := exec.Command("docker", "inspect", "-f", "{{.State.Running}}", fc.id).CombinedOutput()
 	if err != nil || strings.TrimSpace(string(out)) != "true" {
 		t.Fatalf("container is not running after specialize without app\nrunning=%s\nlogs:\n%s",
 			strings.TrimSpace(string(out)), fc.logs())
 	}
-	t.Log("Container still running after specialize without app")
 
 	logs := fc.logs()
-
-	// Verify the proxy handled the FERR gracefully.
-	if strings.Contains(logs, "App binary not found") &&
-		strings.Contains(logs, "running as no-op worker") {
-		t.Log("CONFIRMED: Proxy handled FERR without binary gracefully")
-	} else {
-		t.Errorf("Expected no-op worker message during specialization")
+	if !strings.Contains(logs, "running as no-op worker") {
+		t.Fatalf("Proxy did not enter no-op mode during specialization\nlogs:\n%s", logs)
 	}
+	t.Log("Phase 1 PASSED: Container healthy, proxy in no-op mode")
 
-	// Verify no crash: the old fatal should not appear.
-	if strings.Contains(logs, "Failed to start child worker") {
-		t.Errorf("Proxy crashed in specialize() — fix did not work")
-	} else {
-		t.Log("CONFIRMED: No crash in specialize()")
+	// --- Phase 2: Deploy binary ---
+	t.Log("Phase 2: Deploying app...")
+	fc.deployApp(zipPath)
+	out, _ = exec.Command("docker", "exec", fc.id, "ls", "-la", "/home/site/wwwroot/").CombinedOutput()
+	t.Logf("wwwroot after deploy:\n%s", out)
+
+	// --- Phase 3: Simulate pod recycle (docker restart) ---
+	// In production, Kudu calls removeworker/allStandard to kill all pods.
+	// New pods start fresh with content already on the FUSE mount.
+	// docker restart preserves filesystem state but restarts all processes.
+	t.Log("Phase 3: Restarting container (simulating pod recycle)...")
+	fc.restartContainer()
+	fc.waitForPing(90 * time.Second)
+
+	// Specialize the restarted container (like a new pod being assigned).
+	t.Log("Specializing restarted container (binary now exists)...")
+	fc.specialize(map[string]string{
+		"AzureWebJobsStorage": connStr,
+	})
+
+	// --- Phase 4: Verify function is callable ---
+	status, body := fc.sendRequestWithTimeout("GET", "/api/hello", 60*time.Second)
+	if status != 200 {
+		t.Fatalf("expected 200 from /api/hello, got %d\nlogs:\n%s", status, fc.logs())
 	}
-
-	// Verify host completed specialization without errors.
-	if strings.Contains(logs, "ConsecutiveErrors=1") {
-		t.Errorf("Host has ConsecutiveErrors — worker is crash-looping")
-	} else {
-		t.Log("CONFIRMED: Host has no ConsecutiveErrors")
+	if string(body) != "Hello from Go Worker!" {
+		t.Fatalf("expected 'Hello from Go Worker!', got %q", string(body))
 	}
-
-	t.Logf("Full container logs:\n%s", logs)
+	t.Log("Phase 4 PASSED: /api/hello returned 200 after deploy + pod recycle")
 }

--- a/tests/consumption/specialize_before_deploy_test.go
+++ b/tests/consumption/specialize_before_deploy_test.go
@@ -1,0 +1,175 @@
+package consumption
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// azuriteConnString returns the Azurite connection string using the container's
+// Docker bridge IP, so the test container can reach it directly.
+func azuriteConnString(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("docker", "inspect", "azurite",
+		"--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}").CombinedOutput()
+	if err != nil {
+		t.Skipf("Azurite container not found: %v\n%s", err, out)
+	}
+	ip := strings.TrimSpace(string(out))
+	return fmt.Sprintf(
+		"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;"+
+			"AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"+
+			"BlobEndpoint=http://%s:10000/devstoreaccount1;"+
+			"QueueEndpoint=http://%s:10001/devstoreaccount1;"+
+			"TableEndpoint=http://%s:10002/devstoreaccount1;",
+		ip, ip, ip)
+}
+
+// TestSpecializeBeforeDeploy verifies that a container started post-specialization
+// without an app binary remains healthy instead of crash-looping.
+//
+// Production scenario: A function app is created on flex consumption. The
+// container is assigned and specialized, but the user hasn't deployed code yet.
+// The host starts with WEBSITE_PLACEHOLDER_MODE=0, launches the proxy, and the
+// proxy should stay alive as a no-op worker (zero functions).
+//
+// Before the fix, the proxy would fatal at startup with "Proxy requires
+// WEBSITE_PLACEHOLDER_MODE=1", causing a tight crash loop where the host
+// repeatedly restarted the script host (ConsecutiveErrors=0,1,2,...).
+//
+// Uses the MCR native1.0 image with the proxy replaced by a local build.
+func TestSpecializeBeforeDeploy(t *testing.T) {
+	requireDocker(t)
+
+	connStr := azuriteConnString(t)
+
+	// Start the container already specialized (WEBSITE_PLACEHOLDER_MODE=0),
+	// with a real storage connection, and no app binary.
+	fc := buildAndStartFlexSpecialized(t,
+		"Dockerfile.flex-test-specialize-before-deploy",
+		"goworker-specialize-before-deploy:latest",
+		map[string]string{
+			"AzureWebJobsStorage":        connStr,
+			"FUNCTIONS_EXTENSION_VERSION": "~4",
+			"FUNCTIONS_WORKER_RUNTIME":    "native",
+		},
+	)
+
+	// Wait for the host to start and the proxy to initialize.
+	t.Log("Waiting for host to start with proxy as no-op worker...")
+	time.Sleep(30 * time.Second)
+
+	// Verify the container is still running.
+	out, err := exec.Command("docker", "inspect", "-f", "{{.State.Running}}", fc.id).CombinedOutput()
+	if err != nil || strings.TrimSpace(string(out)) != "true" {
+		t.Fatalf("container is not running\nrunning=%s\nlogs:\n%s",
+			strings.TrimSpace(string(out)), fc.logs())
+	}
+
+	logs := fc.logs()
+
+	// Verify the proxy logged the no-op message instead of crashing.
+	if strings.Contains(logs, "Running as no-op worker") {
+		t.Log("CONFIRMED: Proxy is running as no-op worker (no crash)")
+	} else {
+		t.Errorf("Expected 'Running as no-op worker' in logs but not found")
+	}
+
+	// Verify no crash loop: there should be NO ConsecutiveErrors from the
+	// host restarting due to worker failures.
+	if strings.Contains(logs, "ConsecutiveErrors=1") ||
+		strings.Contains(logs, "ConsecutiveErrors=2") {
+		t.Errorf("Unexpected ConsecutiveErrors in logs — proxy should not be crash-looping")
+	} else {
+		t.Log("CONFIRMED: No crash loop (no ConsecutiveErrors)")
+	}
+
+	// Verify the old fatal message does NOT appear.
+	if strings.Contains(logs, "Proxy requires WEBSITE_PLACEHOLDER_MODE=1") {
+		t.Errorf("Old fatal message found — proxy should not crash without placeholder mode")
+	} else {
+		t.Log("CONFIRMED: No fatal placeholder mode message")
+	}
+
+	t.Logf("Full container logs:\n%s", logs)
+}
+
+// TestSpecializeBeforeDeployFullFlow tests the complete production lifecycle
+// for a newly created function app where code is deployed after the container
+// is already specialized.
+//
+// Production flow (from Kudu Legion source):
+//
+//  1. Function app is created → container assigned → specialized (no app binary)
+//  2. Proxy handles FERR, responds with success and empty functions metadata.
+//     Host is specialized, healthy, zero functions. Container stays alive.
+//  3. User deploys code via `func azure functionapp publish` or ARM
+//  4. Kudu uploads package → platform kills all worker pods (removeworker/allStandard)
+//  5. New container starts fresh → specialization → binary exists from FUSE mount
+//  6. /api/hello returns 200
+//
+// This test covers steps 1-2, then verifies the container is healthy.
+// Steps 3-6 are effectively covered by existing tests (e.g. consumption_test.go)
+// that test normal specialization with a pre-baked app.
+//
+// Before the fix, step 2 would crash the proxy (log.Fatalf in specialize()),
+// making the container unhealthy. The platform would find an unhealthy pod
+// and the user would see errors.
+func TestSpecializeBeforeDeployFullFlow(t *testing.T) {
+	requireDocker(t)
+
+	connStr := azuriteConnString(t)
+
+	// Start in placeholder mode with no app pre-baked.
+	fc := buildAndStartFlex(t,
+		"Dockerfile.flex-test-specialize-before-deploy",
+		"goworker-specialize-before-deploy-full:latest")
+	fc.waitForPing(90 * time.Second)
+
+	// Specialize with a real Azurite connection but no app deployed yet.
+	// With the fix, the proxy responds to FERR with success and returns
+	// empty functions metadata — the host proceeds normally.
+	t.Log("Specializing without app deployed...")
+	fc.specialize(map[string]string{
+		"AzureWebJobsStorage": connStr,
+	})
+
+	// Give the host time to complete specialization.
+	time.Sleep(30 * time.Second)
+
+	// Verify container is still running and healthy (proxy didn't crash-loop).
+	out, err := exec.Command("docker", "inspect", "-f", "{{.State.Running}}", fc.id).CombinedOutput()
+	if err != nil || strings.TrimSpace(string(out)) != "true" {
+		t.Fatalf("container is not running after specialize without app\nrunning=%s\nlogs:\n%s",
+			strings.TrimSpace(string(out)), fc.logs())
+	}
+	t.Log("Container still running after specialize without app")
+
+	logs := fc.logs()
+
+	// Verify the proxy handled the FERR gracefully.
+	if strings.Contains(logs, "App binary not found") &&
+		strings.Contains(logs, "running as no-op worker") {
+		t.Log("CONFIRMED: Proxy handled FERR without binary gracefully")
+	} else {
+		t.Errorf("Expected no-op worker message during specialization")
+	}
+
+	// Verify no crash: the old fatal should not appear.
+	if strings.Contains(logs, "Failed to start child worker") {
+		t.Errorf("Proxy crashed in specialize() — fix did not work")
+	} else {
+		t.Log("CONFIRMED: No crash in specialize()")
+	}
+
+	// Verify host completed specialization without errors.
+	if strings.Contains(logs, "ConsecutiveErrors=1") {
+		t.Errorf("Host has ConsecutiveErrors — worker is crash-looping")
+	} else {
+		t.Log("CONFIRMED: Host has no ConsecutiveErrors")
+	}
+
+	t.Logf("Full container logs:\n%s", logs)
+}

--- a/tests/consumption/specialize_before_deploy_test.go
+++ b/tests/consumption/specialize_before_deploy_test.go
@@ -176,3 +176,66 @@ func TestSpecializeBeforeDeployFullFlow(t *testing.T) {
 	}
 	t.Log("Phase 4 PASSED: /api/hello returned 200 after deploy + pod recycle")
 }
+
+// TestSpecializeWithNonExecutableBinary verifies that the proxy catches a
+// missing execute permission on the app binary and reports a clear error
+// instead of a bare "exited with code 1" in App Insights.
+//
+// This covers the case where a user deploys a binary built on Windows or
+// uploads a zip that doesn't preserve Unix permissions.
+func TestSpecializeWithNonExecutableBinary(t *testing.T) {
+	requireDocker(t)
+
+	connStr := azuriteConnString(t)
+	zipPath := buildSampleZipMinimal(t, "httpTrigger")
+
+	// Start in placeholder mode with no app pre-baked.
+	fc := buildAndStartFlex(t,
+		"Dockerfile.flex-test-specialize-before-deploy",
+		"goworker-non-executable-test:latest")
+	fc.waitForPing(90 * time.Second)
+
+	// Deploy the app but WITHOUT execute permissions.
+	// Use deployApp (which does chmod +x), then remove the execute bit.
+	fc.deployApp(zipPath)
+	out, err := exec.Command("docker", "exec", fc.id, "chmod", "-x", "/home/site/wwwroot/app").CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to remove execute permission: %v\n%s", err, out)
+	}
+	out, _ = exec.Command("docker", "exec", fc.id, "ls", "-la", "/home/site/wwwroot/app").CombinedOutput()
+	t.Logf("Binary permissions after chmod -x: %s", strings.TrimSpace(string(out)))
+
+	// Specialize — the proxy should detect the non-executable binary and
+	// report a clear error via FERR response instead of crashing.
+	t.Log("Specializing with non-executable binary...")
+	fc.specialize(map[string]string{
+		"AzureWebJobsStorage": connStr,
+	})
+
+	// Wait for the host to process the specialization.
+	time.Sleep(15 * time.Second)
+
+	logs := fc.logs()
+
+	// Verify the proxy caught the permission issue.
+	if strings.Contains(logs, "not executable") && strings.Contains(logs, "chmod +x") {
+		t.Log("CONFIRMED: Proxy detected non-executable binary and reported clear error")
+	} else {
+		t.Errorf("Expected 'not executable' and 'chmod +x' in logs but not found")
+	}
+
+	// Verify the proxy did NOT crash with a bare error.
+	if strings.Contains(logs, "Failed to start child worker") {
+		t.Errorf("Proxy crashed instead of reporting permission error")
+	} else {
+		t.Log("CONFIRMED: No crash — error reported through FERR response")
+	}
+
+	// Container should still be running (proxy stayed alive).
+	out, err = exec.Command("docker", "inspect", "-f", "{{.State.Running}}", fc.id).CombinedOutput()
+	if err != nil || strings.TrimSpace(string(out)) != "true" {
+		t.Fatalf("container is not running\nrunning=%s\nlogs:\n%s",
+			strings.TrimSpace(string(out)), logs)
+	}
+	t.Log("CONFIRMED: Container still running after permission error")
+}

--- a/tests/consumption/specialize_before_deploy_test.go
+++ b/tests/consumption/specialize_before_deploy_test.go
@@ -51,7 +51,7 @@ func TestSpecializeBeforeDeploy(t *testing.T) {
 		"Dockerfile.flex-test-specialize-before-deploy",
 		"goworker-specialize-before-deploy:latest",
 		map[string]string{
-			"AzureWebJobsStorage":        connStr,
+			"AzureWebJobsStorage":         connStr,
 			"FUNCTIONS_EXTENSION_VERSION": "~4",
 			"FUNCTIONS_WORKER_RUNTIME":    "native",
 		},


### PR DESCRIPTION
## Problem

When a function app is first created on flex consumption, the container is specialized before any code is deployed. The proxy would crash in two scenarios:

1. **Post-specialization startup** (`WEBSITE_PLACEHOLDER_MODE=0`): proxy fatals with `Proxy requires WEBSITE_PLACEHOLDER_MODE=1`, causing a tight crash loop where the host repeatedly restarts the script host (`ConsecutiveErrors=0,1,2,...`).

2. **During FERR handling**: proxy fatals with `Failed to start child worker: fork/exec app: no such file or directory` when trying to exec the non-existent binary.

Additionally:
- When a user's Go app binary crashes, stderr output (panic stack traces, error messages) was lost -- App Insights showed bare exceptions with no inner detail (133 occurrences observed).
- When the app binary lacks execute permissions (common when deploying from Windows), the proxy crashed with a bare `exited with code 1` instead of reporting the actual issue.

## Fix

### 1. Graceful handling of missing binary
Both crash scenarios are now handled gracefully:
- The proxy runs as a **no-op worker**, responding to host messages (init, heartbeats, status, metadata) with empty/success responses
- The host stays healthy with zero functions until the platform recycles pods with deployed content
- Production flow (from Kudu Legion source): after user deploys, Kudu calls `removeworker/allStandard` to kill all worker pods. New pods start fresh with content already mounted via FUSE.

### 2. Stderr capture for crash diagnostics
- Child stderr is captured into a buffer (while still piping to os.Stderr)
- On crash, captured stderr is logged via `log.Printf` so it appears in FunctionAppLogs through the host's `OnOutputDataReceived` handler
- Brief sleep before `os.Exit()` gives the host time to read the output

### 3. Executable permission check
- At startup (exec bypass): checks execute bit before `syscall.Exec`, fatals with clear message mentioning `chmod +x`
- During `specialize()`: checks execute bit before `cmd.Start()`, sends FERR failure response with `RpcException` containing the permission error -- proxy stays alive, host sees the error in App Insights

## Changes

- **proxy/main.go**:
  - Removed fatal at startup when not in placeholder mode without binary
  - Added binary existence check in `specialize()` -- responds with success FERR and enters no-op mode
  - Added executable permission check in both exec bypass and `specialize()`
  - Capture child stderr in buffer, log on crash for App Insights visibility
- **tests/consumption/specialize_before_deploy_test.go**: Three tests:
  - `TestSpecializeBeforeDeploy`: Post-specialization without binary -- verifies no crash loop
  - `TestSpecializeBeforeDeployFullFlow`: Full 4-phase lifecycle -- specialize without binary, deploy, container restart (pod recycle), specialize with binary, `/api/hello` returns 200
  - `TestSpecializeWithNonExecutableBinary`: Deploys binary without execute permissions -- verifies clear error instead of bare crash
- **tests/consumption/consumption_helpers_test.go**: Added `buildAndStartFlexSpecialized()`, `sendRequestWithTimeout()`, `restartHost()`, `restartContainer()` helpers
- **tests/consumption/Dockerfile.flex-test-specialize-before-deploy**: MCR native1.0 image with local proxy build

## Testing

All tests pass:
- `TestSpecializeBeforeDeploy` -- PASS (55s, no crash loop)
- `TestSpecializeBeforeDeployFullFlow` -- PASS (58s, full lifecycle)
- `TestSpecializeWithNonExecutableBinary` -- PASS (37s, permission error caught)
- `TestFlexConsumptionHttpTriggerProxy` -- PASS (42s, no regression)