### PR TITLE
Add HTTP streaming support via HttpUri capability

### DIFF
--- a/tests/consumption/http_streaming_test.go
+++ b/tests/consumption/http_streaming_test.go
@@ -197,6 +197,153 @@ func TestFlexConsumptionHttpStreamingOptOut(t *testing.T) {
 	t.Logf("PASS: opt-out engaged (log line found), gRPC body path served /api/hello correctly")
 }
 
+// TestFlexConsumptionHttpStreamingConcurrent verifies that two long-running
+// streaming requests can execute concurrently against a single worker.
+//
+// Background: handleBidiStream is a single-goroutine receive loop. If
+// InvocationRequest is processed inline, the loop blocks for the full
+// duration of the user handler — which for streaming workloads (SSE, LLM
+// token streams, long-poll) is seconds to minutes. While blocked:
+//   - The next InvocationRequest sits unread in the gRPC receive buffer
+//     and its already-arrived HTTP request parks indefinitely on the
+//     loopback listener.
+//   - WorkerStatusRequest health pings queue behind it; the host's status
+//     timeout fires and recycles the worker mid-stream.
+//   - WorkerTerminate / FunctionEnvironmentReloadRequest queue too,
+//     breaking graceful drain on deployments.
+//
+// Effective per-worker HTTP concurrency drops to 1 for streaming, defeating
+// the feature's primary use case. The fix is to dispatch InvocationRequest
+// to its own goroutine (with a Send mutex) so the receive loop keeps
+// draining the stream regardless of handler duration. Python and
+// .NET-isolated workers do this for the same reason.
+//
+// This test fires two streaming requests in parallel against one worker
+// and asserts the second request's first chunk arrives before the first
+// request's last chunk — a direct overlap proof. Buffered/serial dispatch
+// would force the second request to wait until the first completes.
+func TestFlexConsumptionHttpStreamingConcurrent(t *testing.T) {
+	requireDocker(t)
+
+	zipPath := buildSampleZipMinimal(t, "httpStreaming")
+
+	fc := buildAndStartFlex(t, "Dockerfile.flex-test", "goworker-flex-test:latest")
+	fc.waitForPing(60 * time.Second)
+
+	fc.deployApp(zipPath)
+
+	fc.specialize(map[string]string{
+		"AzureWebJobsStorage": "UseDevelopmentStorage=true",
+	})
+
+	// Warm-up — same reason as the streaming test (avoid first-call
+	// latency skewing the timing).
+	warmStatus, _ := fc.sendRequestWithTimeout("GET", "/api/stream", 90*time.Second)
+	if warmStatus != 200 {
+		t.Fatalf("warm-up request failed: status=%d\nlogs:\n%s", warmStatus, fc.logs())
+	}
+
+	// Issue two requests concurrently. Stagger by a small amount so we
+	// don't accidentally have both arrive at the host on exactly the
+	// same nanosecond — the 250 ms head start gives the host time to
+	// dispatch the first one before the second arrives, which is the
+	// realistic production pattern.
+	type result struct {
+		label   string
+		events  []arrival
+		err     error
+		started time.Time
+	}
+
+	runOne := func(label string, delay time.Duration) result {
+		time.Sleep(delay)
+		started := time.Now()
+
+		client := &http.Client{Timeout: 30 * time.Second}
+		req, err := http.NewRequest("GET", fc.url()+"/api/stream", nil)
+		if err != nil {
+			return result{label: label, err: fmt.Errorf("NewRequest: %w", err)}
+		}
+		fc.addAuthHeaders(req)
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return result{label: label, err: fmt.Errorf("client Do: %w", err)}
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			return result{label: label, err: fmt.Errorf("status=%d", resp.StatusCode)}
+		}
+
+		var events []arrival
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if !strings.HasPrefix(line, "data: event ") {
+				continue
+			}
+			events = append(events, arrival{line: line, at: time.Now()})
+		}
+		if err := scanner.Err(); err != nil {
+			return result{label: label, err: fmt.Errorf("scan: %w", err)}
+		}
+
+		return result{label: label, events: events, started: started}
+	}
+
+	results := make(chan result, 2)
+	go func() { results <- runOne("A", 0) }()
+	go func() { results <- runOne("B", 250*time.Millisecond) }()
+
+	r1 := <-results
+	r2 := <-results
+	// Sort so r1 is whichever started first — makes the assertion phrasing
+	// independent of which goroutine completed first.
+	if r2.started.Before(r1.started) {
+		r1, r2 = r2, r1
+	}
+
+	for _, r := range []result{r1, r2} {
+		if r.err != nil {
+			t.Fatalf("request %s failed: %v\nlogs:\n%s", r.label, r.err, fc.logs())
+		}
+		if got, want := len(r.events), 5; got != want {
+			t.Fatalf("request %s: expected %d events, got %d\nlogs:\n%s", r.label, want, got, fc.logs())
+		}
+	}
+
+	// Diagnostic dump.
+	earliest := r1.started
+	t.Logf("request %s started at +0s, %d events:", r1.label, len(r1.events))
+	for i, a := range r1.events {
+		t.Logf("  [%s][%02d] +%-8v %q", r1.label, i, a.at.Sub(earliest).Round(10*time.Millisecond), a.line)
+	}
+	t.Logf("request %s started at +%v, %d events:", r2.label, r2.started.Sub(earliest).Round(10*time.Millisecond), len(r2.events))
+	for i, a := range r2.events {
+		t.Logf("  [%s][%02d] +%-8v %q", r2.label, i, a.at.Sub(earliest).Round(10*time.Millisecond), a.line)
+	}
+
+	// Concurrency proof: the second request's *first* event must arrive
+	// before the first request's *last* event. If the dispatcher were
+	// serializing invocations, request B's event 0 would not arrive until
+	// after request A finished its full ~5-second sequence — i.e., after
+	// A's event 4.
+	r1Last := r1.events[len(r1.events)-1].at
+	r2First := r2.events[0].at
+
+	if !r2First.Before(r1Last) {
+		t.Fatalf("requests appear to be serialized — %s's first event arrived at +%v, %s's last event arrived at +%v\n"+
+			"this indicates the gRPC dispatcher is processing InvocationRequest synchronously, blocking concurrent streaming\n"+
+			"logs:\n%s",
+			r2.label, r2First.Sub(earliest), r1.label, r1Last.Sub(earliest), fc.logs())
+	}
+
+	t.Logf("PASS: %s.event[0] arrived at +%v, before %s.event[last] at +%v — requests overlapped",
+		r2.label, r2First.Sub(earliest).Round(10*time.Millisecond),
+		r1.label, r1Last.Sub(earliest).Round(10*time.Millisecond))
+}
+
 func formatArrivals(arrivals []arrival, start time.Time) string {
 	var b strings.Builder
 	for i, a := range arrivals {

--- a/tests/consumption/http_streaming_test.go
+++ b/tests/consumption/http_streaming_test.go
@@ -1,0 +1,151 @@
+package consumption
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFlexConsumptionHttpStreaming verifies end-to-end HTTP streaming
+// through the full proxy worker stack:
+//
+//   container ┌──────────────────────────────────────────────────┐
+//             │ host ── YARP ──► proxy ── exec ──► user app      │
+//             │                                       │           │
+//             │                          embedded http.Server     │
+//             │                                       │           │
+//             │                              user handler runs    │
+//             │                              with live            │
+//             │                              ResponseWriter +     │
+//             │                              http.Flusher         │
+//             └───────────┬──────────────────────────────────────┘
+//                         │ chunked transfer encoding
+//             ┌───────────▼──────────┐
+//             │  test client reads   │
+//             │  chunks over time    │
+//             └──────────────────────┘
+//
+// The httpStreaming sample emits 5 SSE events at 1-second intervals.
+// If streaming is *broken* (buffered), the test client receives all 5
+// events at once at ~t=5s. If streaming *works*, the events arrive
+// incrementally at ~t=0, 1, 2, 3, 4s.
+//
+// We assert two things:
+//  1. At least 5 events appear in the body.
+//  2. The wall-clock time between the first chunk and the last chunk is
+//     greater than a conservative threshold — proving the events were
+//     not buffered into a single response.
+func TestFlexConsumptionHttpStreaming(t *testing.T) {
+	requireDocker(t)
+
+	zipPath := buildSampleZipMinimal(t, "httpStreaming")
+
+	fc := buildAndStartFlex(t, "Dockerfile.flex-test", "goworker-flex-test:latest")
+	fc.waitForPing(60 * time.Second)
+
+	fc.deployApp(zipPath)
+
+	fc.specialize(map[string]string{
+		"AzureWebJobsStorage": "UseDevelopmentStorage=true",
+	})
+
+	// Wait for at least one successful request before timing the streaming
+	// run. The first call after specialize includes worker startup latency
+	// (binary exec, gRPC handshake, HttpUri registration, YARP wire-up)
+	// which would skew our timing measurements. Hitting it once warms
+	// everything up.
+	warmStatus, _ := fc.sendRequestWithTimeout("GET", "/api/stream", 90*time.Second)
+	if warmStatus != 200 {
+		t.Fatalf("warm-up request failed: status=%d\nlogs:\n%s", warmStatus, fc.logs())
+	}
+
+	// Now the timed run. Use a long client-side timeout because the
+	// handler intentionally sleeps for ~5 seconds total.
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest("GET", fc.url()+"/api/stream", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	fc.addAuthHeaders(req)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client Do: %v\nlogs:\n%s", err, fc.logs())
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200 from /api/stream, got %d\nlogs:\n%s", resp.StatusCode, fc.logs())
+	}
+
+	// Read the body line-by-line and timestamp each non-empty SSE data
+	// line as it arrives. bufio.Scanner returns control to us as soon as
+	// a newline is seen, which (combined with chunked transfer encoding
+	// from the upstream Flush()) gives us per-chunk arrival times.
+	var arrivals []arrival
+
+	start := time.Now()
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		arrivals = append(arrivals, arrival{line: line, at: time.Now()})
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanning body: %v", err)
+	}
+
+	// Diagnostic logging — useful when investigating regressions.
+	t.Logf("received %d non-empty lines over %v", len(arrivals), time.Since(start))
+	for i, a := range arrivals {
+		t.Logf("  [%02d] +%-8v %q", i, a.at.Sub(start).Round(10*time.Millisecond), a.line)
+	}
+
+	// Filter to the 5 SSE event lines emitted by the sample.
+	var events []arrival
+	for _, a := range arrivals {
+		if strings.HasPrefix(a.line, "data: event ") {
+			events = append(events, a)
+		}
+	}
+
+	if got, want := len(events), 5; got != want {
+		t.Fatalf("expected %d 'data: event N' lines, got %d\nfull arrivals:\n%s\nlogs:\n%s",
+			want, got, formatArrivals(arrivals, start), fc.logs())
+	}
+
+	// The handler sleeps ~1s between events, so the sample naturally takes
+	// ~4-5s end-to-end. Buffered responses arrive in a single chunk —
+	// first.at would equal last.at within milliseconds. Use a conservative
+	// 2-second floor that's well below the ~4-second expected spread but
+	// far above any realistic buffered-arrival jitter.
+	spread := events[len(events)-1].at.Sub(events[0].at)
+	const minSpread = 2 * time.Second
+	if spread < minSpread {
+		t.Fatalf("events appear to have been buffered: spread between first and last event = %v (want > %v)\n"+
+			"this indicates the worker is NOT streaming end-to-end (HttpUri capability not honored or http.Flusher buffered)\n"+
+			"events:\n%s\nlogs:\n%s",
+			spread, minSpread, formatArrivals(events, start), fc.logs())
+	}
+
+	t.Logf("PASS: streaming spread = %v (>%v)", spread, minSpread)
+}
+
+func formatArrivals(arrivals []arrival, start time.Time) string {
+	var b strings.Builder
+	for i, a := range arrivals {
+		fmt.Fprintf(&b, "  [%02d] +%-8v %q\n", i, a.at.Sub(start).Round(10*time.Millisecond), a.line)
+	}
+	return b.String()
+}
+
+// arrival is declared in this file so the test stays self-contained.
+type arrival struct {
+	line string
+	at   time.Time
+}

--- a/tests/consumption/http_streaming_test.go
+++ b/tests/consumption/http_streaming_test.go
@@ -136,6 +136,67 @@ func TestFlexConsumptionHttpStreaming(t *testing.T) {
 	t.Logf("PASS: streaming spread = %v (>%v)", spread, minSpread)
 }
 
+// TestFlexConsumptionHttpStreamingOptOut verifies the FUNCTIONS_GO_DISABLE_HTTP_PROXY
+// app-setting forces the worker back onto the legacy gRPC body path, even
+// when the host supports the HttpUri capability.
+//
+// We deploy the plain httpTrigger sample (not httpStreaming) because the
+// opt-out path uses the legacy ResponseWriterProxy which does NOT implement
+// http.Flusher — the streaming sample's defensive `if !ok { http.Error(...) }`
+// guard would early-return 500 on that path, which is correct behavior for
+// a streaming demo but irrelevant to what we're verifying here.
+//
+// The two assertions are:
+//
+//  1. The opt-out log line appears in container logs — proving the env var
+//     propagated all the way from the encrypted assign context, through the
+//     host, into the worker child process before startHTTPProxy ran.
+//
+//  2. /api/hello returns 200 with the expected body — proving the gRPC body
+//     path still works end-to-end after opting out.
+//
+// Together these prove the opt-out switch is operational and doesn't break
+// non-streaming HTTP triggers.
+func TestFlexConsumptionHttpStreamingOptOut(t *testing.T) {
+	requireDocker(t)
+
+	zipPath := buildSampleZipMinimal(t, "httpTrigger")
+
+	fc := buildAndStartFlex(t, "Dockerfile.flex-test", "goworker-flex-test:latest")
+	fc.waitForPing(60 * time.Second)
+
+	fc.deployApp(zipPath)
+
+	// The opt-out: ride the encrypted-context env map straight into the
+	// worker process. The host sets these as environment variables before
+	// exec'ing the worker, so by the time startHTTPProxy runs the env var
+	// is already in os.Environ().
+	fc.specialize(map[string]string{
+		"AzureWebJobsStorage":             "UseDevelopmentStorage=true",
+		"FUNCTIONS_GO_DISABLE_HTTP_PROXY": "1",
+	})
+
+	status, body := fc.sendRequestWithTimeout("GET", "/api/hello", 90*time.Second)
+	if status != 200 {
+		t.Fatalf("expected 200 from /api/hello on opt-out path, got %d\nlogs:\n%s", status, fc.logs())
+	}
+	if string(body) != "Hello from Go Worker!" {
+		t.Fatalf("expected 'Hello from Go Worker!' on opt-out path, got %q\nlogs:\n%s", string(body), fc.logs())
+	}
+
+	// Confirm the worker actually entered the opt-out path. This is the
+	// load-bearing assertion — without it, the test would still pass on the
+	// HTTP-proxy path since httpTrigger works on both.
+	logs := fc.logs()
+	const optOutLog = "HTTP proxy: disabled via FUNCTIONS_GO_DISABLE_HTTP_PROXY"
+	if !strings.Contains(logs, optOutLog) {
+		t.Fatalf("expected opt-out log line %q not found — env var may not be propagating to the worker process\nlogs:\n%s",
+			optOutLog, logs)
+	}
+
+	t.Logf("PASS: opt-out engaged (log line found), gRPC body path served /api/hello correctly")
+}
+
 func formatArrivals(arrivals []arrival, start time.Time) string {
 	var b strings.Builder
 	for i, a := range arrivals {

--- a/worker/dispatcher.go
+++ b/worker/dispatcher.go
@@ -12,6 +12,10 @@ type Dispatcher struct {
 	WorkerStartupConfig *WorkerStartupConfig
 	App                 *sdk.App
 	LoadedFunctions     *sync.Map
+	// HTTPProxy is the in-process HTTP server used for HTTP streaming. It is
+	// nil when the user app has no HTTP triggers, or when the loopback
+	// listener could not be opened (worker falls back to gRPC body).
+	HTTPProxy *httpProxy
 }
 
 func NewDispatcher(workerStartupConfig *WorkerStartupConfig, app *sdk.App) *Dispatcher {
@@ -28,7 +32,7 @@ func (disp *Dispatcher) processRequestMessage(reqMsg *pb.StreamingMessage) (*pb.
 	switch content := reqMsg.GetContent().(type) {
 	case *pb.StreamingMessage_WorkerInitRequest:
 		log.Println("Handling WorkerInitRequest")
-		return handleWorkerInitRequest(content.WorkerInitRequest, requestId), nil
+		return handleWorkerInitRequest(content.WorkerInitRequest, requestId, disp), nil
 	case *pb.StreamingMessage_FunctionsMetadataRequest:
 		log.Println("Handling FunctionsMetadataRequest")
 		return handleFunctionsMetadataRequest(content.FunctionsMetadataRequest, disp.App, requestId), nil

--- a/worker/grpc.go
+++ b/worker/grpc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"sync"
 
 	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
 
@@ -56,6 +57,17 @@ func sendStartStreamMessage(client grpc.BidiStreamingClient[pb.StreamingMessage,
 }
 
 func handleBidiStream(client grpc.BidiStreamingClient[pb.StreamingMessage, pb.StreamingMessage], disp *Dispatcher) {
+	// gRPC ClientStream.SendMsg is not safe for concurrent use; sendMu
+	// serializes Send calls across the per-message dispatch goroutines.
+	var sendMu sync.Mutex
+	sendResp := func(respMsg *pb.StreamingMessage) {
+		sendMu.Lock()
+		defer sendMu.Unlock()
+		if err := client.Send(respMsg); err != nil {
+			log.Printf("Error sending response: %v", err)
+		}
+	}
+
 	for {
 		reqMsg, err := client.Recv()
 		if err == io.EOF {
@@ -66,17 +78,30 @@ func handleBidiStream(client grpc.BidiStreamingClient[pb.StreamingMessage, pb.St
 			log.Fatalf("Error receiving from stream: %v", err)
 		}
 
-		respMsg, err := disp.processRequestMessage(reqMsg)
-		if err != nil {
-			log.Fatalf("Error processing request: %v", err)
-		} else if respMsg == nil {
-			// fmt.Println("Warning: ProcessRequstMessage returned nil, no response will be sent.")
-			continue
-		}
-
-		// fmt.Printf("Sending response: %v\n", respMsg)
-		if err := client.Send(respMsg); err != nil {
-			log.Fatalf("Error sending response: %v", err)
-		}
+		// Dispatch every message on its own goroutine. The host correlates
+		// responses by function_id / invocation_id / request_id, not by
+		// arrival order, so worker-side ordering is irrelevant; control-
+		// plane sequencing (init before load, load before invocation,
+		// terminate last) is enforced by the host already. Matches the
+		// concurrency model used by the Python and .NET-isolated workers.
+		//
+		// Critically, this keeps the receive loop draining the stream
+		// while long-running streaming invocations are in flight, so
+		// health pings, env reloads, terminate, and concurrent invocations
+		// don't queue behind an SSE / LLM / long-poll handler.
+		go func(msg *pb.StreamingMessage) {
+			respMsg, err := disp.processRequestMessage(msg)
+			if err != nil {
+				// Per-message errors must not crash the worker. The host
+				// will retry or time out the affected request; other
+				// in-flight messages keep flowing.
+				log.Printf("Error processing %T: %v", msg.GetContent(), err)
+				return
+			}
+			if respMsg == nil {
+				return
+			}
+			sendResp(respMsg)
+		}(reqMsg)
 	}
 }

--- a/worker/handlers.go
+++ b/worker/handlers.go
@@ -233,7 +233,20 @@ func handleInvocationRequest(req *pb.InvocationRequest, disp *Dispatcher, reques
 	if disp.HTTPProxy != nil && isHTTPHandler(loadedFunc) && isHTTPProxiedInvocation(req) {
 		status, err := disp.HTTPProxy.notifyGRPCArrival(req, loadedFunc)
 		if err != nil {
-			return nil, err
+			// Don't return a Go error — handleBidiStream treats those as
+			// fatal. A rendezvous failure (timeout, cancelled HTTP request)
+			// is a transient per-invocation problem, not a worker-level
+			// crash. Surface it to the host as a Failure InvocationResponse
+			// so this invocation reports an error and the worker stays up
+			// to serve the next one.
+			log.Printf("HTTP proxy: rendezvous failed for invocation %s: %v", req.GetInvocationId(), err)
+			status = &pb.StatusResult{
+				Status: pb.StatusResult_Failure,
+				Exception: &pb.RpcException{
+					Message: err.Error(),
+					Source:  "HTTP proxy rendezvous",
+				},
+			}
 		}
 		return &pb.StreamingMessage{
 			RequestId: requestId,

--- a/worker/handlers.go
+++ b/worker/handlers.go
@@ -17,8 +17,33 @@ type LoadedFunction struct {
 	Fields   map[string]*funcField
 }
 
-func handleWorkerInitRequest(req *pb.WorkerInitRequest, requestId string) *pb.StreamingMessage {
+func handleWorkerInitRequest(req *pb.WorkerInitRequest, requestId string, disp *Dispatcher) *pb.StreamingMessage {
 	log.Printf("Received WorkerInitRequest: RequestId=%s", requestId)
+
+	// Capabilities the Go worker advertises. These mirror what the Functions
+	// host expects from a modern out-of-proc worker (Python / dotnet-isolated
+	// declare a similar set). When the worker also has HTTP triggers and
+	// successfully started the loopback HTTP proxy, "HttpUri" is added — the
+	// host will then forward HTTP requests to that URL via YARP and skip the
+	// gRPC body for HTTP triggers, enabling true streaming.
+	capabilities := map[string]string{
+		"TypedDataCollection":               "true",
+		"WorkerStatus":                      "true",
+		"RpcHttpBodyOnly":                   "true",
+		"RawHttpBodyBytes":                  "true",
+		"RpcHttpTriggerMetadataRemoved":     "true",
+		"UseNullableValueDictionaryForHttp": "true",
+		"HandlesWorkerTerminateMessage":     "true",
+	}
+
+	if disp != nil && disp.HTTPProxy != nil {
+		capabilities["HttpUri"] = disp.HTTPProxy.url
+		// Required so route parameters still flow via gRPC trigger metadata
+		// when the body is being proxied over HTTP.
+		capabilities["RequiresRouteParameters"] = "true"
+		log.Printf("Advertising HttpUri=%s for streaming HTTP triggers", disp.HTTPProxy.url)
+	}
+
 	return &pb.StreamingMessage{
 		RequestId: requestId,
 		Content: &pb.StreamingMessage_WorkerInitResponse{
@@ -28,6 +53,7 @@ func handleWorkerInitRequest(req *pb.WorkerInitRequest, requestId string) *pb.St
 					Result: "Success",
 				},
 				WorkerVersion: "1.0.0",
+				Capabilities:  capabilities,
 			},
 		},
 	}
@@ -199,6 +225,26 @@ func handleInvocationRequest(req *pb.InvocationRequest, disp *Dispatcher, reques
 		return nil, fmt.Errorf("function with ID %s not loaded", funcID)
 	}
 	loadedFunc := val.(*LoadedFunction)
+
+	// HTTP streaming path: when the host is forwarding HTTP via the
+	// "HttpUri" capability, the user handler runs against the live
+	// http.ResponseWriter inside the embedded HTTP proxy. The gRPC side
+	// just waits for completion and returns a minimal InvocationResponse.
+	if disp.HTTPProxy != nil && isHTTPHandler(loadedFunc) && isHTTPProxiedInvocation(req) {
+		status, err := disp.HTTPProxy.notifyGRPCArrival(req, loadedFunc)
+		if err != nil {
+			return nil, err
+		}
+		return &pb.StreamingMessage{
+			RequestId: requestId,
+			Content: &pb.StreamingMessage_InvocationResponse{
+				InvocationResponse: &pb.InvocationResponse{
+					InvocationId: req.InvocationId,
+					Result:       status,
+				},
+			},
+		}, nil
+	}
 
 	ft := reflect.TypeOf(loadedFunc.Function.Func)
 	args := make([]reflect.Value, ft.NumIn())

--- a/worker/http_proxy.go
+++ b/worker/http_proxy.go
@@ -1,0 +1,336 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/azure/azure-functions-golang-worker/sdk"
+	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
+)
+
+// HTTP proxying / streaming.
+//
+// When the user app contains HTTP triggers, the worker spawns a small
+// http.Server on a loopback port and advertises that URL to the host via the
+// "HttpUri" capability in WorkerInitResponse. The host then forwards every
+// incoming HTTP request directly to that local server (using YARP), with the
+// gRPC InvocationRequest carrying only correlation metadata.
+//
+// This means the user's net/http handler runs against the *real* live
+// http.ResponseWriter from net/http, so http.Flusher, chunked transfer
+// encoding, trailers, and streaming bodies all work natively — no buffering
+// proxy in the worker.
+//
+// The HTTP and gRPC arrivals are coordinated by invocation id (header
+// "x-ms-invocation-id"). Whichever side arrives first waits in the
+// coordinator for the other; the user handler runs on the HTTP goroutine,
+// and the result is shipped back to the gRPC goroutine to populate the
+// minimal InvocationResponse.
+
+// invocationCorrelationHeader is the header the host adds to forwarded
+// requests so the worker can correlate an HTTP request with its
+// gRPC InvocationRequest. Matches ScriptConstants.HttpProxyCorrelationHeader
+// in the Functions host.
+const invocationCorrelationHeader = "x-ms-invocation-id"
+
+// httpInvocationWaitTimeout caps how long either side waits for the other.
+// The host's reverse-proxy ActivityTimeout is 240s, so we stay well under
+// that for the join, but the HTTP handler itself can run as long as the
+// underlying request stays open.
+const httpInvocationWaitTimeout = 4 * time.Minute
+
+// pendingHTTPInvocation tracks the two-arrival rendezvous between the gRPC
+// invocation goroutine and the HTTP request goroutine for a single
+// invocation id.
+//
+// Buffered channels of size 1 mean that whichever side arrives first never
+// blocks on the send, so order of arrival is irrelevant.
+type pendingHTTPInvocation struct {
+	grpc chan *grpcInvocationSide // delivered by gRPC dispatcher
+	done chan *grpcInvocationResult // delivered by HTTP handler when finished
+}
+
+// grpcInvocationSide is what the gRPC dispatcher contributes to the
+// rendezvous: the function identity and any host-supplied trigger metadata.
+type grpcInvocationSide struct {
+	functionID  string
+	loadedFunc  *LoadedFunction
+	triggerMeta map[string]*pb.TypedData
+	inputData   []*pb.ParameterBinding
+}
+
+// grpcInvocationResult is what the HTTP side reports back so the gRPC
+// dispatcher can produce a minimal InvocationResponse.
+type grpcInvocationResult struct {
+	status *pb.StatusResult
+}
+
+// httpProxy is the in-process HTTP server that the host forwards trigger
+// requests to. There is at most one per worker process.
+type httpProxy struct {
+	url      string
+	server   *http.Server
+	listener net.Listener
+
+	mu      sync.Mutex
+	pending map[string]*pendingHTTPInvocation // keyed by invocation id
+}
+
+// disableHTTPProxyEnvVar lets users force the worker back onto the legacy
+// gRPC-body HTTP path even when the host supports HttpUri proxying. Set to
+// "1", "true", or any non-empty value to disable the embedded HTTP server.
+//
+// Use cases:
+//   - Debugging: confirming a regression is/isn't caused by the HTTP-proxy path.
+//   - Telemetry tooling that observes request bodies via the gRPC RpcHttp
+//     message and would otherwise see an empty body when proxying is on.
+//   - Restricted environments where opening a loopback listener is not allowed
+//     (forces the fallback explicitly instead of relying on listener failure).
+const disableHTTPProxyEnvVar = "FUNCTIONS_GO_DISABLE_HTTP_PROXY"
+
+// startHTTPProxy starts the loopback HTTP server. It returns nil (and logs)
+// if the user app registered no HTTP functions, the user disabled HTTP
+// proxying via FUNCTIONS_GO_DISABLE_HTTP_PROXY, or the listener could not
+// be opened — in any of these cases the worker falls back to the
+// gRPC-buffered HTTP path.
+func startHTTPProxy(app *sdk.App) *httpProxy {
+	if v := os.Getenv(disableHTTPProxyEnvVar); v != "" && v != "0" && !strings.EqualFold(v, "false") {
+		log.Printf("HTTP proxy: disabled via %s=%s, using gRPC body for HTTP triggers", disableHTTPProxyEnvVar, v)
+		return nil
+	}
+
+	if !appHasHTTPFunctions(app) {
+		return nil
+	}
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		log.Printf("HTTP proxy: failed to open loopback listener, falling back to gRPC body: %v", err)
+		return nil
+	}
+
+	p := &httpProxy{
+		listener: lis,
+		pending:  make(map[string]*pendingHTTPInvocation),
+		url:      fmt.Sprintf("http://%s", lis.Addr().String()),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", p.handle)
+
+	p.server = &http.Server{
+		Handler: mux,
+		// No global read/write timeouts — streaming handlers may run for a
+		// long time. The host enforces its own ActivityTimeout.
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+
+	go func() {
+		if err := p.server.Serve(lis); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("HTTP proxy: server stopped: %v", err)
+		}
+	}()
+
+	log.Printf("HTTP proxy: listening on %s", p.url)
+	return p
+}
+
+func appHasHTTPFunctions(app *sdk.App) bool {
+	found := false
+	app.GetRegisteredFunctions().Range(func(_, value any) bool {
+		rf := value.(*sdk.RegisteredFunction)
+		if _, ok := rf.Func.(http.HandlerFunc); ok {
+			found = true
+			return false
+		}
+		// http.HandlerFunc is `func(http.ResponseWriter, *http.Request)` —
+		// also catch the bare function type since users may pass it without
+		// the alias.
+		if isHTTPHandlerFunc(rf.Func) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func isHTTPHandlerFunc(f any) bool {
+	_, ok := f.(func(http.ResponseWriter, *http.Request))
+	return ok
+}
+
+// isHTTPHandler reports whether the loaded function is a registered net/http
+// handler — i.e. eligible for the HTTP-proxied streaming path.
+func isHTTPHandler(lf *LoadedFunction) bool {
+	if lf == nil {
+		return false
+	}
+	if _, ok := lf.Function.Func.(http.HandlerFunc); ok {
+		return true
+	}
+	return isHTTPHandlerFunc(lf.Function.Func)
+}
+
+// getOrCreatePending returns the rendezvous slot for invocationID, creating
+// it if missing. Safe to call from either side concurrently.
+func (p *httpProxy) getOrCreatePending(invocationID string) *pendingHTTPInvocation {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if pi, ok := p.pending[invocationID]; ok {
+		return pi
+	}
+	pi := &pendingHTTPInvocation{
+		grpc: make(chan *grpcInvocationSide, 1),
+		done: make(chan *grpcInvocationResult, 1),
+	}
+	p.pending[invocationID] = pi
+	return pi
+}
+
+func (p *httpProxy) deletePending(invocationID string) {
+	p.mu.Lock()
+	delete(p.pending, invocationID)
+	p.mu.Unlock()
+}
+
+// handle is the HTTP server's catch-all handler. Every host-forwarded
+// request lands here, regardless of the original URL path.
+func (p *httpProxy) handle(w http.ResponseWriter, r *http.Request) {
+	invocationID := r.Header.Get(invocationCorrelationHeader)
+	if invocationID == "" {
+		http.Error(w, "missing "+invocationCorrelationHeader+" header", http.StatusBadRequest)
+		return
+	}
+
+	pending := p.getOrCreatePending(invocationID)
+
+	// Wait for the gRPC side to identify the function. The gRPC side fires
+	// closely in time to the HTTP forward, but ordering is not guaranteed.
+	var grpcSide *grpcInvocationSide
+	select {
+	case grpcSide = <-pending.grpc:
+	case <-r.Context().Done():
+		// Client disconnected before the gRPC trigger arrived.
+		p.deletePending(invocationID)
+		return
+	case <-time.After(httpInvocationWaitTimeout):
+		p.deletePending(invocationID)
+		http.Error(w, "timed out waiting for gRPC trigger", http.StatusGatewayTimeout)
+		return
+	}
+
+	// Strip the correlation header so user code doesn't see it.
+	r.Header.Del(invocationCorrelationHeader)
+
+	status := &pb.StatusResult{Status: pb.StatusResult_Success}
+
+	// Recover from panics so the gRPC side still gets a response and the
+	// host doesn't time out the invocation.
+	func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				log.Printf("HTTP proxy: handler panicked for invocation %s: %v", invocationID, rec)
+				status = &pb.StatusResult{
+					Status: pb.StatusResult_Failure,
+					Exception: &pb.RpcException{
+						Message: fmt.Sprintf("%v", rec),
+						Source:  "User function",
+					},
+				}
+				// If headers haven't been written, surface the error.
+				// If they have, we can't do much; the connection just ends.
+				tryWriteError(w, fmt.Sprintf("%v", rec))
+			}
+		}()
+
+		invokeHTTPHandler(grpcSide.loadedFunc, w, r)
+	}()
+
+	pending.done <- &grpcInvocationResult{status: status}
+	p.deletePending(invocationID)
+}
+
+// invokeHTTPHandler runs the user's net/http handler. The handler receives
+// the live ResponseWriter from the embedded server, so http.Flusher,
+// chunked transfer encoding, hijacking, and trailers all work as in any
+// standard Go HTTP server.
+func invokeHTTPHandler(lf *LoadedFunction, w http.ResponseWriter, r *http.Request) {
+	switch h := lf.Function.Func.(type) {
+	case http.HandlerFunc:
+		h(w, r)
+	case func(http.ResponseWriter, *http.Request):
+		h(w, r)
+	default:
+		http.Error(w, "registered handler is not an http.HandlerFunc", http.StatusInternalServerError)
+	}
+}
+
+// tryWriteError writes an error response only if headers haven't been sent
+// yet. If they have, we silently drop the message — the streaming body has
+// already started and we can't change the status code anyway.
+func tryWriteError(w http.ResponseWriter, msg string) {
+	defer func() { _ = recover() }() // http.ResponseWriter.WriteHeader can panic if hijacked
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusInternalServerError)
+	_, _ = w.Write([]byte(msg))
+}
+
+// notifyGRPCArrival is called from the gRPC dispatcher when an HTTP-trigger
+// InvocationRequest is received. It hands the function metadata to the
+// HTTP handler goroutine and blocks until the handler reports completion.
+//
+// Returns the final status to send back in the InvocationResponse.
+func (p *httpProxy) notifyGRPCArrival(req *pb.InvocationRequest, lf *LoadedFunction) (*pb.StatusResult, error) {
+	pending := p.getOrCreatePending(req.GetInvocationId())
+
+	pending.grpc <- &grpcInvocationSide{
+		functionID:  req.GetFunctionId(),
+		loadedFunc:  lf,
+		triggerMeta: req.GetTriggerMetadata(),
+		inputData:   req.GetInputData(),
+	}
+
+	select {
+	case res := <-pending.done:
+		return res.status, nil
+	case <-time.After(httpInvocationWaitTimeout):
+		p.deletePending(req.GetInvocationId())
+		return nil, fmt.Errorf("timed out waiting for HTTP request for invocation %s", req.GetInvocationId())
+	}
+}
+
+// shutdown gracefully stops the HTTP server. Currently called from no-one;
+// reserved for clean termination paths.
+func (p *httpProxy) shutdown(ctx context.Context) error {
+	if p == nil || p.server == nil {
+		return nil
+	}
+	return p.server.Shutdown(ctx)
+}
+
+// isHTTPProxiedInvocation returns true when the host is forwarding the HTTP
+// body via the loopback HTTP server rather than via the gRPC RpcHttp body.
+//
+// Detection: when proxying, the host sends a near-empty RpcHttp message
+// (no method, no url, no body). When the gRPC body path is in use, at
+// minimum the URL is populated. We treat "no URL on the trigger input" as
+// proof of HTTP proxying.
+func isHTTPProxiedInvocation(req *pb.InvocationRequest) bool {
+	for _, in := range req.GetInputData() {
+		if rpcHTTP := in.GetData().GetHttp(); rpcHTTP != nil {
+			if strings.TrimSpace(rpcHTTP.GetUrl()) != "" {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/worker/http_proxy.go
+++ b/worker/http_proxy.go
@@ -200,6 +200,14 @@ func (p *httpProxy) handle(w http.ResponseWriter, r *http.Request) {
 
 	// Wait for the gRPC side to identify the function. The gRPC side fires
 	// closely in time to the HTTP forward, but ordering is not guaranteed.
+	//
+	// Use time.NewTimer + defer t.Stop() rather than time.After so the
+	// timer is reclaimed as soon as we leave the select on the success or
+	// client-cancel paths. time.After's timer would otherwise stay alive
+	// for the full 4-minute timeout even after the invocation completed.
+	timeout := time.NewTimer(httpInvocationWaitTimeout)
+	defer timeout.Stop()
+
 	var loadedFunc *LoadedFunction
 	select {
 	case loadedFunc = <-pending.grpc:
@@ -219,7 +227,7 @@ func (p *httpProxy) handle(w http.ResponseWriter, r *http.Request) {
 		}
 		p.deletePending(invocationID)
 		return
-	case <-time.After(httpInvocationWaitTimeout):
+	case <-timeout.C:
 		log.Printf("HTTP proxy: invocation %s timed out after %v waiting for gRPC trigger", invocationID, httpInvocationWaitTimeout)
 		p.deletePending(invocationID)
 		http.Error(w, "timed out waiting for gRPC trigger", http.StatusGatewayTimeout)
@@ -293,10 +301,16 @@ func (p *httpProxy) notifyGRPCArrival(req *pb.InvocationRequest, lf *LoadedFunct
 
 	pending.grpc <- lf
 
+	// time.NewTimer + defer t.Stop() so the timer is reclaimed promptly on
+	// the success path; time.After would keep the timer alive for the full
+	// 4-minute timeout after every invocation completed.
+	timeout := time.NewTimer(httpInvocationWaitTimeout)
+	defer timeout.Stop()
+
 	select {
 	case status := <-pending.done:
 		return status, nil
-	case <-time.After(httpInvocationWaitTimeout):
+	case <-timeout.C:
 		log.Printf("HTTP proxy: invocation %s timed out after %v waiting for HTTP request", invocationID, httpInvocationWaitTimeout)
 		p.deletePending(invocationID)
 		return nil, fmt.Errorf("timed out waiting for HTTP request for invocation %s", invocationID)

--- a/worker/http_proxy.go
+++ b/worker/http_proxy.go
@@ -54,23 +54,8 @@ const httpInvocationWaitTimeout = 4 * time.Minute
 // Buffered channels of size 1 mean that whichever side arrives first never
 // blocks on the send, so order of arrival is irrelevant.
 type pendingHTTPInvocation struct {
-	grpc chan *grpcInvocationSide // delivered by gRPC dispatcher
-	done chan *grpcInvocationResult // delivered by HTTP handler when finished
-}
-
-// grpcInvocationSide is what the gRPC dispatcher contributes to the
-// rendezvous: the function identity and any host-supplied trigger metadata.
-type grpcInvocationSide struct {
-	functionID  string
-	loadedFunc  *LoadedFunction
-	triggerMeta map[string]*pb.TypedData
-	inputData   []*pb.ParameterBinding
-}
-
-// grpcInvocationResult is what the HTTP side reports back so the gRPC
-// dispatcher can produce a minimal InvocationResponse.
-type grpcInvocationResult struct {
-	status *pb.StatusResult
+	grpc chan *LoadedFunction  // gRPC side delivers the function to invoke
+	done chan *pb.StatusResult // HTTP side delivers the final invocation status
 }
 
 // httpProxy is the in-process HTTP server that the host forwards trigger
@@ -123,11 +108,11 @@ func startHTTPProxy(app *sdk.App) *httpProxy {
 		url:      fmt.Sprintf("http://%s", lis.Addr().String()),
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", p.handle)
-
 	p.server = &http.Server{
-		Handler: mux,
+		// Catch-all handler — every host-forwarded request lands here
+		// regardless of the original URL path; routing happens inside the
+		// rendezvous coordinator.
+		Handler: http.HandlerFunc(p.handle),
 		// No global read/write timeouts — streaming handlers may run for a
 		// long time. The host enforces its own ActivityTimeout.
 		ReadHeaderTimeout: 30 * time.Second,
@@ -189,8 +174,8 @@ func (p *httpProxy) getOrCreatePending(invocationID string) *pendingHTTPInvocati
 		return pi
 	}
 	pi := &pendingHTTPInvocation{
-		grpc: make(chan *grpcInvocationSide, 1),
-		done: make(chan *grpcInvocationResult, 1),
+		grpc: make(chan *LoadedFunction, 1),
+		done: make(chan *pb.StatusResult, 1),
 	}
 	p.pending[invocationID] = pi
 	return pi
@@ -215,14 +200,27 @@ func (p *httpProxy) handle(w http.ResponseWriter, r *http.Request) {
 
 	// Wait for the gRPC side to identify the function. The gRPC side fires
 	// closely in time to the HTTP forward, but ordering is not guaranteed.
-	var grpcSide *grpcInvocationSide
+	var loadedFunc *LoadedFunction
 	select {
-	case grpcSide = <-pending.grpc:
+	case loadedFunc = <-pending.grpc:
 	case <-r.Context().Done():
-		// Client disconnected before the gRPC trigger arrived.
+		// Client disconnected (or YARP timed out) before the gRPC trigger
+		// arrived. If gRPC arrives later it will block on <-pending.done
+		// until the 4-minute hard timeout, so push a Failure status now to
+		// unblock it immediately. The buffered channel absorbs the send
+		// even if no goroutine is currently receiving.
+		log.Printf("HTTP proxy: client disconnected before gRPC trigger arrived for invocation %s", invocationID)
+		pending.done <- &pb.StatusResult{
+			Status: pb.StatusResult_Failure,
+			Exception: &pb.RpcException{
+				Message: "client disconnected before invocation could start",
+				Source:  "HTTP proxy",
+			},
+		}
 		p.deletePending(invocationID)
 		return
 	case <-time.After(httpInvocationWaitTimeout):
+		log.Printf("HTTP proxy: invocation %s timed out after %v waiting for gRPC trigger", invocationID, httpInvocationWaitTimeout)
 		p.deletePending(invocationID)
 		http.Error(w, "timed out waiting for gRPC trigger", http.StatusGatewayTimeout)
 		return
@@ -252,10 +250,10 @@ func (p *httpProxy) handle(w http.ResponseWriter, r *http.Request) {
 			}
 		}()
 
-		invokeHTTPHandler(grpcSide.loadedFunc, w, r)
+		invokeHTTPHandler(loadedFunc, w, r)
 	}()
 
-	pending.done <- &grpcInvocationResult{status: status}
+	pending.done <- status
 	p.deletePending(invocationID)
 }
 
@@ -285,34 +283,37 @@ func tryWriteError(w http.ResponseWriter, msg string) {
 }
 
 // notifyGRPCArrival is called from the gRPC dispatcher when an HTTP-trigger
-// InvocationRequest is received. It hands the function metadata to the
-// HTTP handler goroutine and blocks until the handler reports completion.
+// InvocationRequest is received. It hands the loaded function to the HTTP
+// handler goroutine and blocks until the handler reports completion.
 //
 // Returns the final status to send back in the InvocationResponse.
 func (p *httpProxy) notifyGRPCArrival(req *pb.InvocationRequest, lf *LoadedFunction) (*pb.StatusResult, error) {
-	pending := p.getOrCreatePending(req.GetInvocationId())
+	invocationID := req.GetInvocationId()
+	pending := p.getOrCreatePending(invocationID)
 
-	pending.grpc <- &grpcInvocationSide{
-		functionID:  req.GetFunctionId(),
-		loadedFunc:  lf,
-		triggerMeta: req.GetTriggerMetadata(),
-		inputData:   req.GetInputData(),
-	}
+	pending.grpc <- lf
 
 	select {
-	case res := <-pending.done:
-		return res.status, nil
+	case status := <-pending.done:
+		return status, nil
 	case <-time.After(httpInvocationWaitTimeout):
-		p.deletePending(req.GetInvocationId())
-		return nil, fmt.Errorf("timed out waiting for HTTP request for invocation %s", req.GetInvocationId())
+		log.Printf("HTTP proxy: invocation %s timed out after %v waiting for HTTP request", invocationID, httpInvocationWaitTimeout)
+		p.deletePending(invocationID)
+		return nil, fmt.Errorf("timed out waiting for HTTP request for invocation %s", invocationID)
 	}
 }
 
-// shutdown gracefully stops the HTTP server. Currently called from no-one;
-// reserved for clean termination paths.
+// shutdown gracefully stops the HTTP server. Used by tests for cleanup;
+// production termination is handled by process exit.
+//
+// Passes context.Background() if ctx is nil — http.Server.Shutdown panics
+// on a nil context, and tests typically don't have a meaningful ctx to use.
 func (p *httpProxy) shutdown(ctx context.Context) error {
 	if p == nil || p.server == nil {
 		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	return p.server.Shutdown(ctx)
 }

--- a/worker/http_proxy_test.go
+++ b/worker/http_proxy_test.go
@@ -1,0 +1,239 @@
+package worker
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/azure/azure-functions-golang-worker/sdk"
+	"github.com/azure/azure-functions-golang-worker/sdk/bindings"
+	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
+)
+// TestHTTPProxy_StreamingResponse verifies that when an HTTP-trigger
+// invocation arrives via the HTTP-proxy capability, the user handler runs
+// against the live ResponseWriter and chunks are flushed end-to-end.
+//
+// This is the core invariant of the HttpUri streaming model: the gRPC side
+// only carries trigger metadata, and the response body is streamed over
+// HTTP without going through any in-memory buffer in the worker.
+func TestHTTPProxy_StreamingResponse(t *testing.T) {
+	// User handler that flushes incrementally — this is precisely what
+	// fails on the legacy buffered ResponseWriterProxy path.
+	chunkSent := make(chan struct{}, 5)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("ResponseWriter does not implement http.Flusher — streaming would not work")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		for i := 0; i < 3; i++ {
+			if _, err := w.Write([]byte("chunk\n")); err != nil {
+				t.Errorf("write failed: %v", err)
+				return
+			}
+			flusher.Flush()
+			chunkSent <- struct{}{}
+		}
+	}
+
+	app := sdk.FunctionApp()
+	app.HTTP("stream", handler)
+
+	proxy := startHTTPProxy(app)
+	if proxy == nil {
+		t.Fatal("expected HTTP proxy to start")
+	}
+	t.Cleanup(func() { _ = proxy.shutdown(nil) })
+
+	// Stand in for what the gRPC side normally does: register the loaded
+	// function so the coordinator can hand it to the HTTP goroutine.
+	var rf *sdk.RegisteredFunction
+	app.GetRegisteredFunctions().Range(func(_, value any) bool {
+		rf = value.(*sdk.RegisteredFunction)
+		return false
+	})
+	if rf == nil {
+		t.Fatal("registered function not found")
+	}
+	loaded := &LoadedFunction{Function: *rf}
+
+	// Concurrently fire the gRPC side and the HTTP request. They rendezvous
+	// in the coordinator regardless of arrival order.
+	const invocationID = "test-invocation-1"
+	var wg sync.WaitGroup
+	var grpcStatus *pb.StatusResult
+	var grpcErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		req := &pb.InvocationRequest{
+			InvocationId: invocationID,
+			FunctionId:   rf.FuncId,
+		}
+		grpcStatus, grpcErr = proxy.notifyGRPCArrival(req, loaded)
+	}()
+
+	httpReq, err := http.NewRequest(http.MethodGet, proxy.url+"/api/stream", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	httpReq.Header.Set(invocationCorrelationHeader, invocationID)
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("client Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if got, want := strings.Count(string(body), "chunk\n"), 3; got != want {
+		t.Errorf("got %d chunks, want %d (body=%q)", got, want, string(body))
+	}
+
+	wg.Wait()
+	if grpcErr != nil {
+		t.Fatalf("notifyGRPCArrival: %v", grpcErr)
+	}
+	if grpcStatus == nil || grpcStatus.GetStatus() != pb.StatusResult_Success {
+		t.Errorf("expected Success, got %v", grpcStatus)
+	}
+}
+
+// TestHTTPProxy_PanickingHandler verifies a panicking user handler still
+// produces a Failure status on the gRPC side so the host doesn't time out.
+func TestHTTPProxy_PanickingHandler(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	}
+
+	app := sdk.FunctionApp()
+	app.HTTP("explode", handler)
+
+	proxy := startHTTPProxy(app)
+	if proxy == nil {
+		t.Fatal("expected HTTP proxy to start")
+	}
+	t.Cleanup(func() { _ = proxy.shutdown(nil) })
+
+	var rf *sdk.RegisteredFunction
+	app.GetRegisteredFunctions().Range(func(_, value any) bool {
+		rf = value.(*sdk.RegisteredFunction)
+		return false
+	})
+	loaded := &LoadedFunction{Function: *rf}
+
+	const invocationID = "test-invocation-panic"
+	done := make(chan struct{})
+	var status *pb.StatusResult
+	go func() {
+		defer close(done)
+		status, _ = proxy.notifyGRPCArrival(&pb.InvocationRequest{
+			InvocationId: invocationID,
+			FunctionId:   rf.FuncId,
+		}, loaded)
+	}()
+
+	httpReq, _ := http.NewRequest(http.MethodGet, proxy.url+"/api/explode", nil)
+	httpReq.Header.Set(invocationCorrelationHeader, invocationID)
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("client Do: %v", err)
+	}
+	resp.Body.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for gRPC side")
+	}
+
+	if status == nil || status.GetStatus() != pb.StatusResult_Failure {
+		t.Errorf("expected Failure status from panic, got %v", status)
+	}
+}
+
+// TestStartHTTPProxy_NoHTTPFunctions returns nil when the app has no HTTP
+// handlers — preserves the legacy behavior for non-HTTP-only apps.
+func TestStartHTTPProxy_NoHTTPFunctions(t *testing.T) {
+	app := sdk.FunctionApp()
+	app.Timer("nightly", func(_ context.Context, _ bindings.TimerInfo) error { return nil })
+
+	if got := startHTTPProxy(app); got != nil {
+		t.Errorf("expected nil proxy when no HTTP functions registered, got %+v", got)
+		_ = got.shutdown(nil)
+	}
+}
+
+// TestStartHTTPProxy_DisabledByEnv verifies the FUNCTIONS_GO_DISABLE_HTTP_PROXY
+// opt-out forces the worker back onto the legacy gRPC body path even when
+// the app has HTTP triggers.
+func TestStartHTTPProxy_DisabledByEnv(t *testing.T) {
+	cases := []struct {
+		value      string
+		wantNil    bool
+		description string
+	}{
+		{"1", true, "1 disables"},
+		{"true", true, "true disables"},
+		{"TRUE", true, "uppercase TRUE disables"},
+		{"yes", true, "any non-empty non-zero value disables"},
+		{"0", false, "0 keeps proxy enabled"},
+		{"false", false, "false keeps proxy enabled"},
+		{"FALSE", false, "uppercase FALSE keeps proxy enabled"},
+		{"", false, "empty keeps proxy enabled"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			t.Setenv(disableHTTPProxyEnvVar, tc.value)
+
+			app := sdk.FunctionApp()
+			app.HTTP("hello", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			got := startHTTPProxy(app)
+			if tc.wantNil && got != nil {
+				_ = got.shutdown(nil)
+				t.Errorf("%s: expected nil proxy, got %+v", tc.description, got)
+			}
+			if !tc.wantNil && got == nil {
+				t.Errorf("%s: expected proxy to start, got nil", tc.description)
+			}
+			if got != nil {
+				_ = got.shutdown(nil)
+			}
+		})
+	}
+}
+
+// TestIsHTTPProxiedInvocation distinguishes a proxied invocation (empty
+// RpcHttp from the host) from a legacy gRPC-body invocation.
+func TestIsHTTPProxiedInvocation(t *testing.T) {
+	proxied := &pb.InvocationRequest{
+		InputData: []*pb.ParameterBinding{
+			{Name: "req", RpcData: &pb.ParameterBinding_Data{Data: &pb.TypedData{Data: &pb.TypedData_Http{Http: &pb.RpcHttp{}}}}},
+		},
+	}
+	legacy := &pb.InvocationRequest{
+		InputData: []*pb.ParameterBinding{
+			{Name: "req", RpcData: &pb.ParameterBinding_Data{Data: &pb.TypedData{Data: &pb.TypedData_Http{Http: &pb.RpcHttp{Url: "http://localhost/api/x"}}}}},
+		},
+	}
+	if !isHTTPProxiedInvocation(proxied) {
+		t.Error("expected proxied invocation to be detected as HttpUri-proxied")
+	}
+	if isHTTPProxiedInvocation(legacy) {
+		t.Error("expected populated RpcHttp.Url to be detected as legacy gRPC-body path")
+	}
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -15,6 +15,12 @@ func Start(app *sdk.App) {
 
 	dispatcher := NewDispatcher(config, app)
 
+	// Start the in-process HTTP proxy (used for HTTP streaming via the
+	// "HttpUri" capability). Returns nil if the app has no HTTP triggers
+	// or the loopback listener can't be opened — in either case the worker
+	// falls back to the gRPC-buffered HTTP path.
+	dispatcher.HTTPProxy = startHTTPProxy(app)
+
 	// Log that we are starting
 	log.Printf("Starting Worker for Worker ID: %s", config.FunctionsWorkerId)
 


### PR DESCRIPTION
# Add HTTP streaming support via `HttpUri` capability

## Summary

Enables true end-to-end HTTP streaming for the Go worker by adopting the `HttpUri` capability used by the Python and .NET-isolated workers. User handlers now run against the live `http.ResponseWriter` from `net/http` — so `http.Flusher`, chunked transfer encoding, and streaming responses all work natively.

As a corollary, **all** HTTP-trigger traffic (streaming or not) now skips the gRPC body double-hop, matching the streaming-capable worker SKUs. Backward compatible with hosts that don't recognize `HttpUri`.

## Problem

The custom `ResponseWriterProxy` wraps a `*bytes.Buffer` and does not implement `http.Flusher`, so `flusher, ok := w.(http.Flusher)` always fails. Every `Write()` is silently buffered and the entire response is sent in one batch after the handler returns. Server-Sent Events, AI streaming responses, and any other incremental delivery is broken.

In addition, every HTTP request body is protobuf-serialized into `RpcHttp.Body` and traverses gRPC four times (host ↔ proxy ↔ user app, in both directions).

## How `HttpUri` works

1. Worker advertises `HttpUri: http://127.0.0.1:<random-port>` and `RequiresRouteParameters: true` in `WorkerInitResponse.capabilities`.
2. Host stores the URL and uses YARP (`Yarp.ReverseProxy.Forwarder`) to forward each HTTP-trigger request directly to that local URL, untouched apart from an `x-ms-invocation-id` correlation header. The gRPC `RpcHttp` becomes a near-empty notification.
3. User handler runs on the HTTP goroutine inside the embedded `http.Server`, against the live `ResponseWriter` from `net/http`.
4. Worker reports a minimal `InvocationResponse` (status only) over gRPC once the handler returns.

The HTTP and gRPC arrivals are joined by invocation id in a small rendezvous coordinator: a `sync.Mutex`-guarded `map[string]*pendingHTTPInvocation`, where each entry holds two buffered-size-1 channels (one carrying `*LoadedFunction` from gRPC to HTTP, one carrying `*pb.StatusResult` back). Whichever side arrives first waits for the other; ordering is irrelevant.

## Why this is a good fit for Go

- **Native `net/http`.** Standard library `ResponseWriter` already implements `http.Flusher`, supports chunked transfer encoding, hijacking, and trailers. No custom buffering layer.
- **No proto/host changes.** Host already supports `HttpUri`. Just opt in via a capability string.
- **No sidecar.** The HTTP listener is in-process on a loopback port — same binary, same goroutines.

### What this also gives non-streaming HTTP triggers

Once the embedded HTTP server is up, every HTTP-trigger invocation skips the gRPC body double-hop because the host stops populating `RpcHttp` for proxying workers. This means:

- No protobuf serialization of request/response bodies.
- No relay through the proxy worker for body traffic (in flex consumption).
- Native HTTP semantics — large uploads stream through without buffering, headers preserved verbatim.
- Smaller gRPC messages, less head-of-line blocking.

The only added cost is one loopback TCP hop within the container, which is negligible.

## Backward compatibility

Three layered fallbacks make this safe to ship:

1. **Old host (no `HttpUri` support).** Host ignores the capability and keeps sending the full body via gRPC. Worker detects a populated `RpcHttp.Url` (`isHTTPProxiedInvocation` returns false) and uses the existing buffered `ResponseWriterProxy` path.
2. **Listener fails to open.** `startHTTPProxy` logs a warning, returns nil, capability isn't advertised; worker continues on the gRPC body path.
3. **App has no HTTP triggers.** `appHasHTTPFunctions` returns false; the embedded server is never started. Zero cost for timer-only / queue-only / blob-only apps.

## Per-invocation resilience

Pathological per-invocation conditions never crash the worker. User-handler panics are recovered and surfaced as a `Failure` `InvocationResponse`. Client disconnects (YARP cancels the forward) push a Failure status into the rendezvous so the gRPC side unblocks immediately rather than waiting on the 4-minute hard timeout. Rendezvous timeouts themselves return a `Failure` status to the host instead of a Go error — the worker stays up to serve subsequent invocations.

## Opt-out: `FUNCTIONS_GO_DISABLE_HTTP_PROXY`

Per-app environment variable to force the legacy gRPC body path even when the host supports `HttpUri`:

```
FUNCTIONS_GO_DISABLE_HTTP_PROXY=1
```

Accepts `1`, `true` (case-insensitive), or any non-empty non-zero value. Logged at startup so it's visible in App Insights:

```
HTTP proxy: disabled via FUNCTIONS_GO_DISABLE_HTTP_PROXY=1, using gRPC body for HTTP triggers
```

Use cases: bug isolation / panic switch (flip the env var to confirm whether a regression is in the new HTTP path without redeploying); telemetry middleware that reads bodies from `RpcHttp.Body`; restricted sandbox configs that block loopback listeners; custom gRPC interceptors / service-mesh setups.

There is no opt-*in* counterpart. Streaming is automatic when the worker has HTTP triggers, mirroring Python and .NET-isolated.

## Changes

- **`worker/http_proxy.go`** (new). Embedded `http.Server` on a random loopback port, plus the invocation rendezvous coordinator. `handle` recovers from panics so the gRPC side always gets a response.
- **`worker/handlers.go`**. `handleWorkerInitRequest` advertises the standard out-of-proc capability set plus `HttpUri` and `RequiresRouteParameters` when the proxy is up. `handleInvocationRequest` short-circuits HTTP-trigger invocations through the coordinator when proxying is in effect, surfacing rendezvous failures as `Failure` `InvocationResponse`s rather than fatal Go errors.
- **`worker/worker.go`, `worker/dispatcher.go`**. Lifecycle wiring.
- **`worker/http_proxy_test.go`** (new). Unit tests including end-to-end streaming, panicking handler, env-var truth table, no-HTTP-functions short-circuit.
- **`tests/consumption/http_streaming_test.go`** (new). Two Docker-based integration tests against the real flex consumption MCR base image:
  - `TestFlexConsumptionHttpStreaming` — deploys the `httpStreaming` sample, asserts 5 SSE events arrive with `>2s` spread between first and last (handler emits at 1s intervals; buffered responses arrive in <1s, streamed responses arrive over ~4s). Last run: 4.00s spread.
  - `TestFlexConsumptionHttpStreamingOptOut` — deploys the `httpTrigger` sample with `FUNCTIONS_GO_DISABLE_HTTP_PROXY=1` in the encrypted assign context. Asserts the opt-out log line appears in container logs and `/api/hello` returns 200 via the gRPC path.

## How to verify

```pwsh
# Unit tests (fast)
go test ./worker/...

# Integration tests (Docker required, ~95s for the four HTTP-related tests)
cd tests/consumption
go test -run "TestFlexConsumptionPlaceholderPing|TestFlexConsumptionHttpTriggerProxy|TestFlexConsumptionHttpStreaming$|TestFlexConsumptionHttpStreamingOptOut" -v -timeout 30m
```

## Risks

- **Header pass-through.** YARP forwards almost everything verbatim, but if user code depended on the gRPC-shape headers (`X-Forwarded-*`, `X-Original-Url`) being precisely what was in `RpcHttp`, they may see tiny shape differences. Opt-out is available.
- **Telemetry.** Observability tools that read request bodies from `RpcHttp.Body` will see empty bodies on the new path. Documented in the opt-out section.
