### PR TITLE
 Fix timer ScheduleStatus deserialization from TypedData_String_

### DIFF
--- a/worker/converter.go
+++ b/worker/converter.go
@@ -55,8 +55,12 @@ func convertToTypeValue(pt reflect.Type, data *pb.TypedData, tm map[string]*pb.T
 
 	// If struct, try JSON decoding first, then fall back to TriggerMetadata field matching
 	if t.Kind() == reflect.Struct {
-		// Try direct JSON unmarshal from input data first
-		if jsonStr := data.GetJson(); jsonStr != "" {
+		// Try direct JSON unmarshal from input data (TypedData_Json or TypedData_String_)
+		jsonStr := data.GetJson()
+		if jsonStr == "" {
+			jsonStr = data.GetString_()
+		}
+		if jsonStr != "" {
 			target := reflect.New(t).Interface()
 			if err := json.Unmarshal([]byte(jsonStr), target); err == nil {
 				val := reflect.ValueOf(target).Elem()
@@ -141,6 +145,11 @@ func decodeProto(data *pb.TypedData, t reflect.Type) (reflect.Value, error) {
 	switch t.Kind() {
 	case reflect.String:
 		return reflect.ValueOf(data.GetString_()), nil
+	case reflect.Bool:
+		if val := data.GetString_(); val != "" {
+			return reflect.ValueOf(strings.EqualFold(val, "true")), nil
+		}
+		return reflect.ValueOf(data.GetInt() != 0), nil
 	case reflect.Slice:
 		if t.Elem().Kind() == reflect.Uint8 {
 			if len(data.GetBytes()) == 0 {

--- a/worker/converter_test.go
+++ b/worker/converter_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/azure/azure-functions-golang-worker/sdk/bindings"
 	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
 )
 
@@ -92,6 +93,33 @@ func TestDecodeProto_NilData(t *testing.T) {
 	}
 	if v.String() != "" {
 		t.Errorf("expected empty string for nil data, got %q", v.String())
+	}
+}
+
+func TestDecodeProto_BoolFromString(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     *pb.TypedData
+		expected bool
+	}{
+		{"True string", &pb.TypedData{Data: &pb.TypedData_String_{String_: "True"}}, true},
+		{"true string", &pb.TypedData{Data: &pb.TypedData_String_{String_: "true"}}, true},
+		{"False string", &pb.TypedData{Data: &pb.TypedData_String_{String_: "False"}}, false},
+		{"false string", &pb.TypedData{Data: &pb.TypedData_String_{String_: "false"}}, false},
+		{"int nonzero", &pb.TypedData{Data: &pb.TypedData_Int{Int: 1}}, true},
+		{"int zero", &pb.TypedData{Data: &pb.TypedData_Int{Int: 0}}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := decodeProto(tc.data, reflect.TypeOf(false))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if v.Bool() != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, v.Bool())
+			}
+		})
 	}
 }
 
@@ -206,6 +234,37 @@ func TestConvertToTypeValue_StructWithTriggerMetadata(t *testing.T) {
 	}
 	if result.MessageId != "msg-123" {
 		t.Errorf("expected messageId %q, got %q", "msg-123", result.MessageId)
+	}
+}
+
+func TestConvertToTypeValue_TimerInfo_StringJSON(t *testing.T) {
+	timerJSON := `{"Schedule":{"AdjustForDST":true},"ScheduleStatus":{"Last":"2026-05-15T17:40:00+00:00","Next":"2026-05-15T17:45:00+00:00","LastUpdated":"2026-05-15T17:40:00+00:00"},"IsPastDue":false}`
+	data := &pb.TypedData{Data: &pb.TypedData_String_{String_: timerJSON}}
+	metadata := map[string]*pb.TypedData{
+		"isPastDue": {Data: &pb.TypedData_String_{String_: "False"}},
+	}
+
+	v, err := convertToTypeValue(reflect.TypeOf(bindings.TimerInfo{}), data, metadata)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := v.Interface().(bindings.TimerInfo)
+
+	if result.ScheduleStatus.Last != "2026-05-15T17:40:00+00:00" {
+		t.Errorf("expected ScheduleStatus.Last %q, got %q",
+			"2026-05-15T17:40:00+00:00", result.ScheduleStatus.Last)
+	}
+	if result.ScheduleStatus.Next != "2026-05-15T17:45:00+00:00" {
+		t.Errorf("expected ScheduleStatus.Next %q, got %q",
+			"2026-05-15T17:45:00+00:00", result.ScheduleStatus.Next)
+	}
+	if result.ScheduleStatus.LastUpdated != "2026-05-15T17:40:00+00:00" {
+		t.Errorf("expected ScheduleStatus.LastUpdated %q, got %q",
+			"2026-05-15T17:40:00+00:00", result.ScheduleStatus.LastUpdated)
+	}
+	if result.Schedule.AdjustForDST != true {
+		t.Errorf("expected Schedule.AdjustForDST true, got %v", result.Schedule.AdjustForDST)
 	}
 }
 


### PR DESCRIPTION
Bug

timer.ScheduleStatus.Last and timer.ScheduleStatus.Next were always empty when accessed in a timer trigger handler.

The Azure Functions host sends timer trigger data as TypedData_String_ (a string containing JSON), not TypedData_Json. The converter only checked GetJson() for struct JSON deserialization, so the full timer JSON was never parsed. Instead, the code fell into a TriggerMetadata field-by-field fallback, which partially matched isPastDue and returned early — leaving ScheduleStatus and Schedule as zero-valued structs.

Fix

 - convertToTypeValue: Also try GetString_() as a JSON source when GetJson() is empty. If the string contains valid JSON for the target struct, it deserializes fully before the TriggerMetadata fallback is consulted.
 - decodeProto: Add reflect.Bool case to handle "True"/"False" strings and int-to-bool conversion from TriggerMetadata.

Evidence

Confirmed via the host repo that ToRpc() routes strings through TypedData.String, not TypedData.Json — matching the observed behavior.

Testing

Added TestConvertToTypeValue_TimerInfo_StringJSON and TestDecodeProto_BoolFromString to reproduce the bug and verify the fix. All existing tests pass with no regressions.