### PR TITLE
Add panic-safe goroutine helpers to the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,33 +144,18 @@ The worker recovers panics that happen **inside your handler** and reports them 
 
 That safety net does **not** extend to goroutines you start yourself. In Go, an unrecovered panic in *any* goroutine terminates the entire process. In an Azure Functions worker this is especially dangerous: the worker hosts multiple concurrent invocations (potentially across different functions), so **one panicking goroutine crashes every in-flight request on the worker**, not just the function that spawned it. The host sees "worker exited" and the real stack never reaches your logs.
 
-### The pattern: `errgroup` + named-return recover
+### Propagate panics as errors: `sdk.RecoverTo`
 
-For work that matters (processing events, calling APIs), use [`errgroup`](https://pkg.go.dev/golang.org/x/sync/errgroup) with a named return so panics propagate as errors and the invocation fails properly — triggering retries instead of silent data loss:
+For work that matters (processing events, calling APIs), use [`sdk.RecoverTo`](sdk/safego.go) so panics propagate as errors and the invocation fails properly — triggering retries instead of silent data loss:
 
 ```go
-import (
-    "fmt"
-    "log/slog"
-    "runtime/debug"
-
-    "golang.org/x/sync/errgroup"
-)
+import "golang.org/x/sync/errgroup"
 
 func EventHubHandler(ctx context.Context, events []bindings.EventHubEvent) error {
     g, ctx := errgroup.WithContext(ctx)
     for _, e := range events {
         g.Go(func() (err error) {
-            defer func() {
-                if r := recover(); r != nil {
-                    // Logged with invocation_id, function_name, trigger_type
-                    // via the SDK's slog handler.
-                    slog.ErrorContext(ctx, "panic processing event",
-                        slog.Any("panic", r),
-                        slog.String("stack", string(debug.Stack())))
-                    err = fmt.Errorf("panic processing event: %v", r)
-                }
-            }()
+            defer sdk.RecoverTo(ctx, &err)
             return process(e)
         })
     }
@@ -178,7 +163,7 @@ func EventHubHandler(ctx context.Context, events []bindings.EventHubEvent) error
 }
 ```
 
-The `slog.ErrorContext(ctx, ...)` call is the Functions-specific piece: the SDK installs its log handler as the default, which pulls invocation metadata off `ctx` and attaches `invocation_id`, `function_name`, and `trigger_type` — so the panic shows up correlated in Application Insights.
+`RecoverTo` logs the full stack trace with invocation metadata (via slog + the SDK log handler) and sets `*errp` to a descriptive error. If `*errp` already holds a non-nil error, the original is preserved.
 
 ### Best-effort work: `sdk.Recover`
 
@@ -195,7 +180,7 @@ go func() {
 wg.Wait()
 ```
 
-> **Rule of thumb:** if a goroutine's failure should fail the invocation, use errgroup with a named-return recover. If the goroutine is truly best-effort, `sdk.Recover` keeps the worker alive with one line.
+> **Rule of thumb:** if a goroutine's failure should fail the invocation, use `sdk.RecoverTo`. If the goroutine is truly best-effort, `sdk.Recover` keeps the worker alive with one line.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -142,34 +142,60 @@ This is similar to the .NET worker extensions model (`Microsoft.Azure.Functions.
 
 The worker recovers panics that happen **inside your handler** and reports them to the host as a failed invocation with the full Go stack trace — so they show up, diagnosable, in Application Insights.
 
-That safety net does **not** extend to goroutines you start yourself. In Go, an unrecovered panic in *any* goroutine terminates the entire process. A handler that launches background work with a bare `go func() { ... }()` therefore puts the whole worker at risk: one nil-pointer dereference on that goroutine crashes the process, fails every other in-flight invocation with an opaque "worker exited" error, and the real stack never reaches the host or your App Insights.
+That safety net does **not** extend to goroutines you start yourself. In Go, an unrecovered panic in *any* goroutine terminates the entire process. In an Azure Functions worker this is especially dangerous: the worker hosts multiple concurrent invocations (potentially across different functions), so **one panicking goroutine crashes every in-flight request on the worker**, not just the function that spawned it. The host sees "worker exited" and the real stack never reaches your logs.
 
-Use [`sdk.Go`](sdk/safego.go) instead of `go` for fire-and-forget work. It runs your function in a panic-guarded goroutine: a panic is recovered, logged at error level with its stack (correlated to the spawning invocation via `slog`), and the worker stays alive.
+### The pattern: `errgroup` + named-return recover
+
+For work that matters (processing events, calling APIs), use [`errgroup`](https://pkg.go.dev/golang.org/x/sync/errgroup) with a named return so panics propagate as errors and the invocation fails properly — triggering retries instead of silent data loss:
 
 ```go
+import (
+    "fmt"
+    "log/slog"
+    "runtime/debug"
+
+    "golang.org/x/sync/errgroup"
+)
+
 func EventHubHandler(ctx context.Context, events []bindings.EventHubEvent) error {
+    g, ctx := errgroup.WithContext(ctx)
     for _, e := range events {
-        e := e
-        sdk.Go(ctx, func() {
-            // A panic in here is recovered and logged — it will NOT crash the worker.
-            process(e)
+        g.Go(func() (err error) {
+            defer func() {
+                if r := recover(); r != nil {
+                    // Logged with invocation_id, function_name, trigger_type
+                    // via the SDK's slog handler.
+                    slog.ErrorContext(ctx, "panic processing event",
+                        slog.Any("panic", r),
+                        slog.String("stack", string(debug.Stack())))
+                    err = fmt.Errorf("panic processing event: %v", r)
+                }
+            }()
+            return process(e)
         })
     }
-    return nil
+    return g.Wait() // non-nil on panic → invocation fails → host retries
 }
 ```
 
-When you need to control how the goroutine is launched (a `sync.WaitGroup`, a worker pool, a named function), defer [`sdk.Recover`](sdk/safego.go) as the first statement instead:
+The `slog.ErrorContext(ctx, ...)` call is the Functions-specific piece: the SDK installs its log handler as the default, which pulls invocation metadata off `ctx` and attaches `invocation_id`, `function_name`, and `trigger_type` — so the panic shows up correlated in Application Insights.
+
+### Best-effort work: `sdk.Recover`
+
+For genuinely best-effort goroutines where failure doesn't affect correctness (cache warming, fire-and-forget telemetry), defer [`sdk.Recover`](sdk/safego.go) to keep the worker alive without the ceremony of error propagation:
 
 ```go
+var wg sync.WaitGroup
+wg.Add(1)
 go func() {
-    defer sdk.Recover(ctx)
+    defer sdk.Recover(ctx) // catches panic, logs with invocation metadata
     defer wg.Done()
-    doBackgroundWork(ctx)
+    warmCache(ctx)
 }()
+wg.Wait()
 ```
 
-> **Rule of thumb:** inside Functions code, reach for `sdk.Go` / `sdk.Recover` instead of a bare `go`. The cost is one identifier; the payoff is that a defect in background work degrades to a logged error instead of a worker crash.
+> **Rule of thumb:** if a goroutine's failure should fail the invocation, use errgroup with a named-return recover. If the goroutine is truly best-effort, `sdk.Recover` keeps the worker alive with one line.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ That safety net does **not** extend to goroutines you start yourself. In Go, an 
 
 ### Propagate panics as errors: `sdk.RecoverTo`
 
-For work that matters (processing events, calling APIs), use [`sdk.RecoverTo`](sdk/safego.go) so panics propagate as errors and the invocation fails properly — triggering retries instead of silent data loss:
+For work that matters (processing events, calling APIs), use [`sdk.RecoverTo`](sdk/safego.go) so panics propagate as errors and the invocation fails properly — triggering retries instead of silent data loss.
+
+**Recommended: errgroup** (no defer-ordering pitfalls — the closure's return is read after all defers run):
 
 ```go
 import "golang.org/x/sync/errgroup"
@@ -161,6 +163,21 @@ func EventHubHandler(ctx context.Context, events []bindings.EventHubEvent) error
     }
     return g.Wait() // non-nil on panic → invocation fails → host retries
 }
+```
+
+**Manual WaitGroup** — register `wg.Done` *before* `RecoverTo` so it fires *after* the error is set (defers run in LIFO order):
+
+```go
+var err error
+var wg sync.WaitGroup
+wg.Add(1)
+go func() {
+    defer wg.Done()                // registered first → runs LAST
+    defer sdk.RecoverTo(ctx, &err) // registered second → runs FIRST (sets err)
+    doWork()
+}()
+wg.Wait()
+return err // safe: err is set before wg.Done unblocks Wait
 ```
 
 `RecoverTo` logs the full stack trace with invocation metadata (via slog + the SDK log handler) and sets `*errp` to a descriptive error. If `*errp` already holds a non-nil error, the original is preserved.

--- a/README.md
+++ b/README.md
@@ -138,12 +138,38 @@ This is similar to the .NET worker extensions model (`Microsoft.Azure.Functions.
 
 ---
 
-## Custom Handlers vs First-Class Go Worker
+## Goroutine safety & panic recovery
 
-Historically, Go was only supported on Azure Functions via "Custom Handlers" (an HTTP-based proxy pattern). This new natively supported Go Worker provides a richer experience:
-1. **gRPC Integration**: The worker connects directly to the host process via an `EventStream`, reducing HTTP proxy overhead.
-2. **First-class Bindings**: You no longer need to parse raw HTTP headers to read trigger/binding data; the gRPC worker deserializes the metadata and binding data directly into your Go objects.
-3. **No configurations:** Function endpoints are discovered cleanly in code without `function.json`.
+The worker recovers panics that happen **inside your handler** and reports them to the host as a failed invocation with the full Go stack trace — so they show up, diagnosable, in Application Insights.
+
+That safety net does **not** extend to goroutines you start yourself. In Go, an unrecovered panic in *any* goroutine terminates the entire process. A handler that launches background work with a bare `go func() { ... }()` therefore puts the whole worker at risk: one nil-pointer dereference on that goroutine crashes the process, fails every other in-flight invocation with an opaque "worker exited" error, and the real stack never reaches the host or your App Insights.
+
+Use [`sdk.Go`](sdk/safego.go) instead of `go` for fire-and-forget work. It runs your function in a panic-guarded goroutine: a panic is recovered, logged at error level with its stack (correlated to the spawning invocation via `slog`), and the worker stays alive.
+
+```go
+func EventHubHandler(ctx context.Context, events []bindings.EventHubEvent) error {
+    for _, e := range events {
+        e := e
+        sdk.Go(ctx, func() {
+            // A panic in here is recovered and logged — it will NOT crash the worker.
+            process(e)
+        })
+    }
+    return nil
+}
+```
+
+When you need to control how the goroutine is launched (a `sync.WaitGroup`, a worker pool, a named function), defer [`sdk.Recover`](sdk/safego.go) as the first statement instead:
+
+```go
+go func() {
+    defer sdk.Recover(ctx)
+    defer wg.Done()
+    doBackgroundWork(ctx)
+}()
+```
+
+> **Rule of thumb:** inside Functions code, reach for `sdk.Go` / `sdk.Recover` instead of a bare `go`. The cost is one identifier; the payoff is that a defect in background work degrades to a logged error instead of a worker crash.
 
 ---
 
@@ -241,6 +267,15 @@ app.Use(otelfunc.Middleware(
 Inbound W3C baggage is hydrated onto `ctx` automatically — read with `baggage.FromContext(ctx)`, propagate to your downstream calls with `otelhttp.NewTransport(...)` / `otelgrpc` interceptors. See `package otelfunc` godoc for full options including `WithTracerProvider`, `WithPropagator`, custom span names, and the `AZURE_FUNCTIONS_WORKER_OPENTELEMETRY_DISABLED` kill switch.
 
 For a deeper architectural overview see the [developer manual](TECHNICAL_SPEC.md).
+
+---
+
+## Custom Handlers vs First-Class Go Worker
+
+Historically, Go was only supported on Azure Functions via "Custom Handlers" (an HTTP-based proxy pattern). This new natively supported Go Worker provides a richer experience:
+1. **gRPC Integration**: The worker connects directly to the host process via an `EventStream`, reducing HTTP proxy overhead.
+2. **First-class Bindings**: You no longer need to parse raw HTTP headers to read trigger/binding data; the gRPC worker deserializes the metadata and binding data directly into your Go objects.
+3. **No configurations:** Function endpoints are discovered cleanly in code without `function.json`.
 
 ## Contributing
 

--- a/sdk/safego.go
+++ b/sdk/safego.go
@@ -27,10 +27,13 @@ import (
 
 // Recover is a panic guard for goroutines you start yourself.
 //
-// Add it as the first defer in any goroutine launched from a handler:
+// It must be the first defer in the goroutine so it runs last and catches
+// panics from all subsequent defers. Defers execute in LIFO order, so the
+// first defer registered is the last to run — placing Recover first
+// guarantees it is the final safety net:
 //
 //	go func() {
-//	    defer sdk.Recover(ctx)
+//	    defer sdk.Recover(ctx)   // ← first defer, runs last: catches everything
 //	    defer wg.Done()
 //	    doWork(ctx)
 //	}()
@@ -62,6 +65,9 @@ func Recover(ctx context.Context) {
 }
 
 // RecoverTo is a panic guard that captures the recovered panic as an error.
+//
+// Like [Recover], it must be the first defer so it runs last and catches
+// panics from all subsequent defers.
 //
 // It is designed for goroutines whose failure should fail the enclosing
 // invocation — triggering host retries and surfacing the error in Application

--- a/sdk/safego.go
+++ b/sdk/safego.go
@@ -90,7 +90,11 @@ func Recover(ctx context.Context) {
 func RecoverTo(ctx context.Context, errp *error) {
 	if r := recover(); r != nil {
 		logRecoveredPanic(ctx, r, debug.Stack())
-		if *errp == nil {
+		// If errp is nil the caller doesn't need the error value; degrade
+		// gracefully to Recover semantics (log and swallow) rather than
+		// crashing on a nil dereference — which would be unrecoverable
+		// since recover() has already consumed the original panic.
+		if errp != nil && *errp == nil {
 			*errp = fmt.Errorf("recovered panic: %v", r)
 		}
 	}

--- a/sdk/safego.go
+++ b/sdk/safego.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"log/slog"
 	"runtime/debug"
-	"sync/atomic"
 )
 
-// This file provides helpers for safely running your own goroutines inside a
+// This file provides a helper for safely running your own goroutines inside a
 // function.
 //
 // Azure Functions already protects you from panics that happen directly in
@@ -22,108 +21,54 @@ import (
 // request currently running on it, and you don't even get a useful error —
 // just "the worker exited." The actual cause never reaches your logs.
 //
-// [Go] and [Recover] close that gap. Wrap your background work with them and a
-// panic in a goroutine becomes a logged error instead of a worker crash.
-
-// Go runs fn in a new goroutine that is protected against panics.
-//
-// Use it instead of `go fn()` whenever you start background work from inside a
-// function. If fn panics, Go recovers it, logs the error and stack trace
-// (tagged with the current invocation so you can find it in Application
-// Insights), and keeps your worker alive — instead of letting one panic crash
-// every request running on it.
-//
-// Pass the handler's ctx so the logged error is linked to the right
-// invocation. Note that Go does not cancel fn when ctx is done; if your
-// goroutine should stop on cancellation, check ctx.Done() yourself.
-//
-// A nil fn does nothing.
-//
-//	func EventHubHandler(ctx context.Context, events []bindings.EventHubEvent) error {
-//	    for _, e := range events {
-//	        e := e
-//	        sdk.Go(ctx, func() {
-//	            // If this panics (say, a nil-pointer dereference), it's logged
-//	            // with a full stack trace instead of crashing the worker.
-//	            process(e)
-//	        })
-//	    }
-//	    return nil
-//	}
-func Go(ctx context.Context, fn func()) {
-	if fn == nil {
-		return
-	}
-	go func() {
-		defer Recover(ctx)
-		fn()
-	}()
-}
+// [Recover] closes that gap. Defer it at the top of any goroutine you start
+// and a panic becomes a logged error instead of a worker crash.
 
 // Recover is a panic guard for goroutines you start yourself.
 //
-// Reach for it when [Go] doesn't fit — for example when your goroutine also
-// needs a `defer wg.Done()`, is part of a worker pool, or is a named function.
-// Add it as the first line of the goroutine:
+// Add it as the first defer in any goroutine launched from a handler:
 //
 //	go func() {
 //	    defer sdk.Recover(ctx)
 //	    defer wg.Done()
-//	    doBackgroundWork(ctx)
+//	    doWork(ctx)
 //	}()
 //
-// If the goroutine panics, Recover catches it, logs the error with a stack
-// trace, and lets the goroutine return quietly so the worker stays up. If
-// there's no panic, it does nothing, so it's always safe to defer.
+// If the goroutine panics, Recover catches it, logs the error with a full
+// stack trace (tagged with the current invocation so it's easy to find in
+// Application Insights), and lets the goroutine exit cleanly so the worker
+// stays up.
 //
-// Recover intentionally stops the panic from propagating — that's how it keeps
-// the worker alive. If your code needs to know the work failed, surface that
-// from inside the goroutine (for example, send on a channel) before it panics.
+// Recover intentionally stops the panic from propagating. To surface the
+// failure to the caller, use a named return and convert the panic to an error:
+//
+//	g, ctx := errgroup.WithContext(ctx)
+//	for _, e := range events {
+//	    g.Go(func() (err error) {
+//	        defer func() {
+//	            if r := recover(); r != nil {
+//	                slog.ErrorContext(ctx, "panic processing event",
+//	                    slog.Any("panic", r),
+//	                    slog.String("stack", string(debug.Stack())))
+//	                err = fmt.Errorf("panic: %v", r)
+//	            }
+//	        }()
+//	        return process(e)
+//	    })
+//	}
+//	return g.Wait()
+//
+// The named-return pattern gives you both: the panic is logged with invocation
+// metadata (via slog + the SDK log handler), and it propagates as an error so
+// the invocation fails and the host can retry.
+//
+// For truly best-effort work where failure doesn't matter (cache warming,
+// opportunistic telemetry), Recover alone is sufficient — it logs and
+// swallows.
 func Recover(ctx context.Context) {
 	if r := recover(); r != nil {
-		goroutinePanicHandler()(ctx, r, debug.Stack())
+		defaultGoroutinePanicHandler(ctx, r, debug.Stack())
 	}
-}
-
-// GoroutinePanicHandler is called by [Go] and [Recover] whenever they recover
-// a panic from a guarded goroutine. recovered is the value passed to panic and
-// stack is the stack trace captured where the panic was caught.
-//
-// Most apps never need this — the default handler logs the panic for you. It's
-// here for advanced cases where you want to report panics somewhere else (for
-// example, an OpenTelemetry exception event or a metric). Your implementation
-// must not panic and should return quickly.
-type GoroutinePanicHandler func(ctx context.Context, recovered any, stack []byte)
-
-// panicHandlerHolder is a swappable pointer to the active panic handler,
-// mirroring the baseHolder pattern in log.go so the behavior can be
-// overridden at runtime without changing call sites.
-var panicHandlerHolder atomic.Pointer[GoroutinePanicHandler]
-
-// SetGoroutinePanicHandler changes what happens when [Go] or [Recover] catch a
-// panic. By default, panics are logged via slog with the recovered value and
-// stack trace attached, tagged with the invocation so they're easy to find in
-// Application Insights — which is all most apps need.
-//
-// Call this only if you want to report panics somewhere else as well (say, an
-// OpenTelemetry exception event or a failure metric). Set it once at startup;
-// it applies process-wide and is safe to call from any goroutine. Pass nil to
-// go back to the default logging behavior.
-func SetGoroutinePanicHandler(h GoroutinePanicHandler) {
-	if h == nil {
-		panicHandlerHolder.Store(nil)
-		return
-	}
-	panicHandlerHolder.Store(&h)
-}
-
-// goroutinePanicHandler returns the active handler, falling back to the
-// default slog-based reporter when none is installed.
-func goroutinePanicHandler() GoroutinePanicHandler {
-	if p := panicHandlerHolder.Load(); p != nil {
-		return *p
-	}
-	return defaultGoroutinePanicHandler
 }
 
 // defaultGoroutinePanicHandler logs the recovered panic and its stack at error

--- a/sdk/safego.go
+++ b/sdk/safego.go
@@ -1,0 +1,137 @@
+package sdk
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+	"sync/atomic"
+)
+
+// This file provides helpers for safely running your own goroutines inside a
+// function.
+//
+// Azure Functions already protects you from panics that happen directly in
+// your handler: if your handler code panics, the worker catches it, fails just
+// that one invocation, and reports the error (with the full stack) to the host
+// and Application Insights. Your app keeps running.
+//
+// That protection does NOT cover goroutines you start yourself with a plain
+// `go func() { ... }()`. In Go, if any goroutine panics and nothing recovers
+// it, the ENTIRE process is torn down. In a Functions worker that means a
+// single bad background goroutine crashes the worker, fails every other
+// request currently running on it, and you don't even get a useful error —
+// just "the worker exited." The actual cause never reaches your logs.
+//
+// [Go] and [Recover] close that gap. Wrap your background work with them and a
+// panic in a goroutine becomes a logged error instead of a worker crash.
+
+// Go runs fn in a new goroutine that is protected against panics.
+//
+// Use it instead of `go fn()` whenever you start background work from inside a
+// function. If fn panics, Go recovers it, logs the error and stack trace
+// (tagged with the current invocation so you can find it in Application
+// Insights), and keeps your worker alive — instead of letting one panic crash
+// every request running on it.
+//
+// Pass the handler's ctx so the logged error is linked to the right
+// invocation. Note that Go does not cancel fn when ctx is done; if your
+// goroutine should stop on cancellation, check ctx.Done() yourself.
+//
+// A nil fn does nothing.
+//
+//	func EventHubHandler(ctx context.Context, events []bindings.EventHubEvent) error {
+//	    for _, e := range events {
+//	        e := e
+//	        sdk.Go(ctx, func() {
+//	            // If this panics (say, a nil-pointer dereference), it's logged
+//	            // with a full stack trace instead of crashing the worker.
+//	            process(e)
+//	        })
+//	    }
+//	    return nil
+//	}
+func Go(ctx context.Context, fn func()) {
+	if fn == nil {
+		return
+	}
+	go func() {
+		defer Recover(ctx)
+		fn()
+	}()
+}
+
+// Recover is a panic guard for goroutines you start yourself.
+//
+// Reach for it when [Go] doesn't fit — for example when your goroutine also
+// needs a `defer wg.Done()`, is part of a worker pool, or is a named function.
+// Add it as the first line of the goroutine:
+//
+//	go func() {
+//	    defer sdk.Recover(ctx)
+//	    defer wg.Done()
+//	    doBackgroundWork(ctx)
+//	}()
+//
+// If the goroutine panics, Recover catches it, logs the error with a stack
+// trace, and lets the goroutine return quietly so the worker stays up. If
+// there's no panic, it does nothing, so it's always safe to defer.
+//
+// Recover intentionally stops the panic from propagating — that's how it keeps
+// the worker alive. If your code needs to know the work failed, surface that
+// from inside the goroutine (for example, send on a channel) before it panics.
+func Recover(ctx context.Context) {
+	if r := recover(); r != nil {
+		goroutinePanicHandler()(ctx, r, debug.Stack())
+	}
+}
+
+// GoroutinePanicHandler is called by [Go] and [Recover] whenever they recover
+// a panic from a guarded goroutine. recovered is the value passed to panic and
+// stack is the stack trace captured where the panic was caught.
+//
+// Most apps never need this — the default handler logs the panic for you. It's
+// here for advanced cases where you want to report panics somewhere else (for
+// example, an OpenTelemetry exception event or a metric). Your implementation
+// must not panic and should return quickly.
+type GoroutinePanicHandler func(ctx context.Context, recovered any, stack []byte)
+
+// panicHandlerHolder is a swappable pointer to the active panic handler,
+// mirroring the baseHolder pattern in log.go so the behavior can be
+// overridden at runtime without changing call sites.
+var panicHandlerHolder atomic.Pointer[GoroutinePanicHandler]
+
+// SetGoroutinePanicHandler changes what happens when [Go] or [Recover] catch a
+// panic. By default, panics are logged via slog with the recovered value and
+// stack trace attached, tagged with the invocation so they're easy to find in
+// Application Insights — which is all most apps need.
+//
+// Call this only if you want to report panics somewhere else as well (say, an
+// OpenTelemetry exception event or a failure metric). Set it once at startup;
+// it applies process-wide and is safe to call from any goroutine. Pass nil to
+// go back to the default logging behavior.
+func SetGoroutinePanicHandler(h GoroutinePanicHandler) {
+	if h == nil {
+		panicHandlerHolder.Store(nil)
+		return
+	}
+	panicHandlerHolder.Store(&h)
+}
+
+// goroutinePanicHandler returns the active handler, falling back to the
+// default slog-based reporter when none is installed.
+func goroutinePanicHandler() GoroutinePanicHandler {
+	if p := panicHandlerHolder.Load(); p != nil {
+		return *p
+	}
+	return defaultGoroutinePanicHandler
+}
+
+// defaultGoroutinePanicHandler logs the recovered panic and its stack at error
+// level. ctx flows through to slog so the sdk log handler can attach
+// invocation metadata (invocation_id, function_name, trigger_type).
+func defaultGoroutinePanicHandler(ctx context.Context, recovered any, stack []byte) {
+	slog.ErrorContext(ctx, "recovered panic in goroutine",
+		slog.Any("panic", recovered),
+		slog.String("stack", string(stack)),
+	)
+}

--- a/sdk/safego.go
+++ b/sdk/safego.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"runtime/debug"
 )
@@ -39,42 +40,60 @@ import (
 // Application Insights), and lets the goroutine exit cleanly so the worker
 // stays up.
 //
-// Recover intentionally stops the panic from propagating. To surface the
-// failure to the caller, use a named return and convert the panic to an error:
+// Recover intentionally stops the panic from propagating. If the goroutine's
+// failure should fail the invocation (trigger retries, surface in App Insights
+// as an error), use [RecoverTo] instead — it captures the panic as an error
+// via a pointer you supply:
 //
 //	g, ctx := errgroup.WithContext(ctx)
-//	for _, e := range events {
-//	    g.Go(func() (err error) {
-//	        defer func() {
-//	            if r := recover(); r != nil {
-//	                slog.ErrorContext(ctx, "panic processing event",
-//	                    slog.Any("panic", r),
-//	                    slog.String("stack", string(debug.Stack())))
-//	                err = fmt.Errorf("panic: %v", r)
-//	            }
-//	        }()
-//	        return process(e)
-//	    })
-//	}
+//	g.Go(func() (err error) {
+//	    defer sdk.RecoverTo(ctx, &err)
+//	    return process(event)
+//	})
 //	return g.Wait()
-//
-// The named-return pattern gives you both: the panic is logged with invocation
-// metadata (via slog + the SDK log handler), and it propagates as an error so
-// the invocation fails and the host can retry.
 //
 // For truly best-effort work where failure doesn't matter (cache warming,
 // opportunistic telemetry), Recover alone is sufficient — it logs and
 // swallows.
 func Recover(ctx context.Context) {
 	if r := recover(); r != nil {
-		defaultGoroutinePanicHandler(ctx, r, debug.Stack())
+		logRecoveredPanic(ctx, r, debug.Stack())
 	}
 }
 
-// defaultGoroutinePanicHandler logs the recovered panic and its stack at error
-// level. ctx flows through to slog so the sdk log handler can attach
-// invocation metadata (invocation_id, function_name, trigger_type).
-func defaultGoroutinePanicHandler(ctx context.Context, recovered any, stack []byte) {
+// RecoverTo is a panic guard that captures the recovered panic as an error.
+//
+// It is designed for goroutines whose failure should fail the enclosing
+// invocation — triggering host retries and surfacing the error in Application
+// Insights — without the boilerplate of a manual recover + named return:
+//
+//	g, ctx := errgroup.WithContext(ctx)
+//	for _, e := range events {
+//	    g.Go(func() (err error) {
+//	        defer sdk.RecoverTo(ctx, &err)
+//	        return process(e)
+//	    })
+//	}
+//	return g.Wait() // non-nil on panic → invocation fails → host retries
+//
+// errp must be non-nil and should point to a named return value. If a panic
+// occurs, RecoverTo logs the full stack trace (with invocation metadata) and
+// sets *errp to a descriptive error. If *errp is already non-nil (i.e., the
+// function returned an error normally before a deferred panic), the original
+// error is preserved.
+func RecoverTo(ctx context.Context, errp *error) {
+	if r := recover(); r != nil {
+		logRecoveredPanic(ctx, r, debug.Stack())
+		if *errp == nil {
+			*errp = fmt.Errorf("recovered panic: %v", r)
+		}
+	}
+}
+
+// logRecoveredPanic logs the recovered panic and its stack at error level.
+// ctx flows through to slog so the sdk log handler can attach invocation
+// metadata (invocation_id, function_name, trigger_type).
+func logRecoveredPanic(ctx context.Context, recovered any, stack []byte) {
 	slog.ErrorContext(ctx, "recovered panic in goroutine",
 		slog.Any("panic", recovered),
 		slog.String("stack", string(stack)),

--- a/sdk/safego.go
+++ b/sdk/safego.go
@@ -66,12 +66,12 @@ func Recover(ctx context.Context) {
 
 // RecoverTo is a panic guard that captures the recovered panic as an error.
 //
-// Like [Recover], it must be the first defer so it runs last and catches
-// panics from all subsequent defers.
-//
 // It is designed for goroutines whose failure should fail the enclosing
 // invocation — triggering host retries and surfacing the error in Application
-// Insights — without the boilerplate of a manual recover + named return:
+// Insights — without the boilerplate of a manual recover + named return.
+//
+// The recommended pattern is [errgroup], which avoids defer-ordering pitfalls
+// entirely because the closure's return value is read after all defers run:
 //
 //	g, ctx := errgroup.WithContext(ctx)
 //	for _, e := range events {
@@ -81,6 +81,21 @@ func Recover(ctx context.Context) {
 //	    })
 //	}
 //	return g.Wait() // non-nil on panic → invocation fails → host retries
+//
+// If you hand-roll synchronization with a WaitGroup, register the
+// synchronization signal (wg.Done, close) BEFORE RecoverTo so it fires AFTER
+// the error is captured (defers run in LIFO order):
+//
+//	var err error
+//	var wg sync.WaitGroup
+//	wg.Add(1)
+//	go func() {
+//	    defer wg.Done()                // registered first → runs LAST
+//	    defer sdk.RecoverTo(ctx, &err) // registered second → runs FIRST (sets err)
+//	    doWork()
+//	}()
+//	wg.Wait()
+//	return err // safe: err is set before wg.Done unblocks Wait
 //
 // errp must be non-nil and should point to a named return value. If a panic
 // occurs, RecoverTo logs the full stack trace (with invocation metadata) and

--- a/sdk/safego_test.go
+++ b/sdk/safego_test.go
@@ -1,0 +1,158 @@
+package sdk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+// waitTimeout blocks until done is closed or the deadline elapses, failing the
+// test on timeout so a broken helper can never hang the suite.
+func waitTimeout(t *testing.T, done <-chan struct{}, msg string) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", msg)
+	}
+}
+
+func TestGo_RunsFn(t *testing.T) {
+	done := make(chan struct{})
+	Go(context.Background(), func() { close(done) })
+	waitTimeout(t, done, "fn to run")
+}
+
+func TestGo_RecoversPanic(t *testing.T) {
+	// A panic inside the goroutine must be recovered (not crash the test
+	// process) and routed to the panic handler.
+	prev := panicHandlerHolder.Load()
+	t.Cleanup(func() { panicHandlerHolder.Store(prev) })
+
+	var (
+		mu       sync.Mutex
+		gotPanic any
+		gotStack []byte
+		handled  = make(chan struct{})
+	)
+	SetGoroutinePanicHandler(func(_ context.Context, recovered any, stack []byte) {
+		mu.Lock()
+		gotPanic = recovered
+		gotStack = stack
+		mu.Unlock()
+		close(handled)
+	})
+
+	Go(context.Background(), func() { panic("boom") })
+
+	waitTimeout(t, handled, "panic handler to be invoked")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotPanic != "boom" {
+		t.Errorf("recovered value mismatch: got %v, want \"boom\"", gotPanic)
+	}
+	if len(gotStack) == 0 {
+		t.Error("expected a non-empty stack trace")
+	}
+}
+
+func TestGo_NilFnIsNoop(t *testing.T) {
+	// Must not panic or spawn anything. If this returns, it passed.
+	Go(context.Background(), nil)
+}
+
+func TestRecover_NoPanicIsNoop(t *testing.T) {
+	// Deferring Recover when no panic is in flight must do nothing and must
+	// not invoke the panic handler.
+	prev := panicHandlerHolder.Load()
+	t.Cleanup(func() { panicHandlerHolder.Store(prev) })
+
+	called := false
+	SetGoroutinePanicHandler(func(context.Context, any, []byte) { called = true })
+
+	func() {
+		defer Recover(context.Background())
+		// no panic
+	}()
+
+	if called {
+		t.Error("panic handler should not be called when there is no panic")
+	}
+}
+
+func TestRecover_GuardsManualGoroutine(t *testing.T) {
+	prev := panicHandlerHolder.Load()
+	t.Cleanup(func() { panicHandlerHolder.Store(prev) })
+
+	handled := make(chan struct{})
+	SetGoroutinePanicHandler(func(context.Context, any, []byte) { close(handled) })
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer Recover(context.Background())
+		defer wg.Done()
+		panic("manual goroutine boom")
+	}()
+	wg.Wait()
+
+	waitTimeout(t, handled, "panic handler from manual goroutine")
+}
+
+func TestSetGoroutinePanicHandler_NilRestoresDefault(t *testing.T) {
+	prev := panicHandlerHolder.Load()
+	t.Cleanup(func() { panicHandlerHolder.Store(prev) })
+
+	SetGoroutinePanicHandler(func(context.Context, any, []byte) {})
+	if panicHandlerHolder.Load() == nil {
+		t.Fatal("expected a custom handler to be installed")
+	}
+
+	SetGoroutinePanicHandler(nil)
+	if panicHandlerHolder.Load() != nil {
+		t.Error("expected nil to clear the custom handler (fall back to default)")
+	}
+}
+
+func TestDefaultGoroutinePanicHandler_LogsViaSlog(t *testing.T) {
+	// The default handler logs the panic at error level through slog so the
+	// sdk log handler can attach invocation metadata. Capture it via a buffer
+	// base handler wrapped by NewLogHandler, with an InvocationContext on ctx.
+	// Invoke the default handler directly (rather than through Go) so the
+	// assertion is deterministic and free of goroutine timing.
+	var buf bytes.Buffer
+	base := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})
+	prevDefault := slog.Default()
+	slog.SetDefault(slog.New(NewLogHandler(base)))
+	t.Cleanup(func() { slog.SetDefault(prevDefault) })
+
+	ctx := NewContext(context.Background(), &InvocationContext{
+		InvocationID: "inv-99",
+		FunctionName: "EventHubHandler",
+		TriggerType:  "eventHubTrigger",
+	})
+
+	defaultGoroutinePanicHandler(ctx, "nil pointer-ish", []byte("goroutine 1 [running]:\n..."))
+
+	var rec map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &rec); err != nil {
+		t.Fatalf("log output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	if rec["level"] != "ERROR" {
+		t.Errorf("expected ERROR level, got %v", rec["level"])
+	}
+	if rec["invocation_id"] != "inv-99" {
+		t.Errorf("expected invocation metadata on the panic log, got %v", rec["invocation_id"])
+	}
+	if rec["panic"] != "nil pointer-ish" {
+		t.Errorf("expected the recovered value in the log, got %v", rec["panic"])
+	}
+	if s, ok := rec["stack"].(string); !ok || s == "" {
+		t.Errorf("expected a non-empty stack attribute, got %v", rec["stack"])
+	}
+}

--- a/sdk/safego_test.go
+++ b/sdk/safego_test.go
@@ -34,8 +34,12 @@ func TestRecover_CatchesPanicInGoroutine(t *testing.T) {
 	// A goroutine that defers Recover must not crash the process on panic.
 	done := make(chan struct{})
 	go func() {
+		// Test-only ordering: close(done) is first so it runs LAST, ensuring
+		// Recover has finished logging before the test unblocks and the next
+		// test swaps the global slog handler. In production code Recover
+		// should be the first defer (see doc comments).
+		defer close(done)
 		defer Recover(context.Background())
-		defer func() { close(done) }()
 		panic("boom")
 	}()
 	waitTimeout(t, done, "goroutine with Recover to complete")
@@ -122,6 +126,16 @@ func TestRecoverTo_NoPanicIsNoop(t *testing.T) {
 	if err := fn(); err != nil {
 		t.Errorf("expected nil error when no panic, got: %v", err)
 	}
+}
+
+func TestRecoverTo_NilErrpDoesNotCrash(t *testing.T) {
+	// Passing a nil errp must not crash — RecoverTo should degrade to
+	// Recover semantics (log and swallow) rather than nil-dereference.
+	func() {
+		defer RecoverTo(context.Background(), nil)
+		panic("nil errp panic")
+	}()
+	// If we reach here without crashing, the test passed.
 }
 
 func TestRecoverTo_NoPanicPreservesReturnedError(t *testing.T) {

--- a/sdk/safego_test.go
+++ b/sdk/safego_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
-	"sync"
 	"testing"
 	"time"
 )
@@ -33,15 +33,11 @@ func TestRecover_NoPanicIsNoop(t *testing.T) {
 func TestRecover_CatchesPanicInGoroutine(t *testing.T) {
 	// A goroutine that defers Recover must not crash the process on panic.
 	done := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
 	go func() {
 		defer Recover(context.Background())
-		defer wg.Done()
 		defer func() { close(done) }()
 		panic("boom")
 	}()
-	wg.Wait()
 	waitTimeout(t, done, "goroutine with Recover to complete")
 }
 
@@ -81,5 +77,59 @@ func TestRecover_LogsViaSlog(t *testing.T) {
 	}
 	if s, ok := rec["stack"].(string); !ok || s == "" {
 		t.Errorf("expected a non-empty stack attribute, got %v", rec["stack"])
+	}
+}
+
+func TestRecoverTo_SetsErrorOnPanic(t *testing.T) {
+	// RecoverTo must capture the panic as an error via the provided pointer.
+	fn := func() (err error) {
+		defer RecoverTo(context.Background(), &err)
+		panic("kaboom")
+	}
+	err := fn()
+	if err == nil {
+		t.Fatal("expected non-nil error after panic")
+	}
+	if got := err.Error(); got != "recovered panic: kaboom" {
+		t.Errorf("unexpected error message: %s", got)
+	}
+}
+
+func TestRecoverTo_PreservesExistingError(t *testing.T) {
+	// If *errp is already non-nil when the panic fires, RecoverTo must not
+	// overwrite it — the original error is the more meaningful signal.
+	original := fmt.Errorf("original error")
+	fn := func() (err error) {
+		defer RecoverTo(context.Background(), &err)
+		err = original
+		panic("secondary boom")
+	}
+	err := fn()
+	if err != original {
+		t.Errorf("expected original error to be preserved, got: %v", err)
+	}
+}
+
+func TestRecoverTo_NoPanicIsNoop(t *testing.T) {
+	// When no panic occurs, RecoverTo must leave *errp untouched.
+	fn := func() (err error) {
+		defer RecoverTo(context.Background(), &err)
+		return nil
+	}
+	if err := fn(); err != nil {
+		t.Errorf("expected nil error when no panic, got: %v", err)
+	}
+}
+
+func TestRecoverTo_NoPanicPreservesReturnedError(t *testing.T) {
+	// When the function returns a real error and no panic happens,
+	// RecoverTo must not interfere.
+	want := fmt.Errorf("real error")
+	fn := func() (err error) {
+		defer RecoverTo(context.Background(), &err)
+		return want
+	}
+	if got := fn(); got != want {
+		t.Errorf("expected %v, got %v", want, got)
 	}
 }

--- a/sdk/safego_test.go
+++ b/sdk/safego_test.go
@@ -44,11 +44,14 @@ func TestRecover_CatchesPanicInGoroutine(t *testing.T) {
 func TestRecover_LogsViaSlog(t *testing.T) {
 	// Recover must log the panic at error level through slog so the SDK log
 	// handler can attach invocation metadata. Verify by capturing output.
+	//
+	// We swap the base handler via the SDK's atomic SetDefaultBaseHandler
+	// rather than calling slog.SetDefault, which would mutate the process-wide
+	// slog default and make this test unsafe to run concurrently with others.
 	var buf bytes.Buffer
 	base := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})
-	prevDefault := slog.Default()
-	slog.SetDefault(slog.New(NewLogHandler(base)))
-	t.Cleanup(func() { slog.SetDefault(prevDefault) })
+	SetDefaultBaseHandler(base)
+	t.Cleanup(func() { SetDefaultBaseHandler(nil) })
 
 	ctx := NewContext(context.Background(), &InvocationContext{
 		InvocationID: "inv-99",

--- a/sdk/safego_test.go
+++ b/sdk/safego_test.go
@@ -21,110 +21,33 @@ func waitTimeout(t *testing.T, done <-chan struct{}, msg string) {
 	}
 }
 
-func TestGo_RunsFn(t *testing.T) {
-	done := make(chan struct{})
-	Go(context.Background(), func() { close(done) })
-	waitTimeout(t, done, "fn to run")
-}
-
-func TestGo_RecoversPanic(t *testing.T) {
-	// A panic inside the goroutine must be recovered (not crash the test
-	// process) and routed to the panic handler.
-	prev := panicHandlerHolder.Load()
-	t.Cleanup(func() { panicHandlerHolder.Store(prev) })
-
-	var (
-		mu       sync.Mutex
-		gotPanic any
-		gotStack []byte
-		handled  = make(chan struct{})
-	)
-	SetGoroutinePanicHandler(func(_ context.Context, recovered any, stack []byte) {
-		mu.Lock()
-		gotPanic = recovered
-		gotStack = stack
-		mu.Unlock()
-		close(handled)
-	})
-
-	Go(context.Background(), func() { panic("boom") })
-
-	waitTimeout(t, handled, "panic handler to be invoked")
-
-	mu.Lock()
-	defer mu.Unlock()
-	if gotPanic != "boom" {
-		t.Errorf("recovered value mismatch: got %v, want \"boom\"", gotPanic)
-	}
-	if len(gotStack) == 0 {
-		t.Error("expected a non-empty stack trace")
-	}
-}
-
-func TestGo_NilFnIsNoop(t *testing.T) {
-	// Must not panic or spawn anything. If this returns, it passed.
-	Go(context.Background(), nil)
-}
-
 func TestRecover_NoPanicIsNoop(t *testing.T) {
-	// Deferring Recover when no panic is in flight must do nothing and must
-	// not invoke the panic handler.
-	prev := panicHandlerHolder.Load()
-	t.Cleanup(func() { panicHandlerHolder.Store(prev) })
-
-	called := false
-	SetGoroutinePanicHandler(func(context.Context, any, []byte) { called = true })
-
+	// Deferring Recover when no panic is in flight must do nothing.
+	// If this returns without hanging or panicking, it passed.
 	func() {
 		defer Recover(context.Background())
 		// no panic
 	}()
-
-	if called {
-		t.Error("panic handler should not be called when there is no panic")
-	}
 }
 
-func TestRecover_GuardsManualGoroutine(t *testing.T) {
-	prev := panicHandlerHolder.Load()
-	t.Cleanup(func() { panicHandlerHolder.Store(prev) })
-
-	handled := make(chan struct{})
-	SetGoroutinePanicHandler(func(context.Context, any, []byte) { close(handled) })
-
+func TestRecover_CatchesPanicInGoroutine(t *testing.T) {
+	// A goroutine that defers Recover must not crash the process on panic.
+	done := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer Recover(context.Background())
 		defer wg.Done()
-		panic("manual goroutine boom")
+		defer func() { close(done) }()
+		panic("boom")
 	}()
 	wg.Wait()
-
-	waitTimeout(t, handled, "panic handler from manual goroutine")
+	waitTimeout(t, done, "goroutine with Recover to complete")
 }
 
-func TestSetGoroutinePanicHandler_NilRestoresDefault(t *testing.T) {
-	prev := panicHandlerHolder.Load()
-	t.Cleanup(func() { panicHandlerHolder.Store(prev) })
-
-	SetGoroutinePanicHandler(func(context.Context, any, []byte) {})
-	if panicHandlerHolder.Load() == nil {
-		t.Fatal("expected a custom handler to be installed")
-	}
-
-	SetGoroutinePanicHandler(nil)
-	if panicHandlerHolder.Load() != nil {
-		t.Error("expected nil to clear the custom handler (fall back to default)")
-	}
-}
-
-func TestDefaultGoroutinePanicHandler_LogsViaSlog(t *testing.T) {
-	// The default handler logs the panic at error level through slog so the
-	// sdk log handler can attach invocation metadata. Capture it via a buffer
-	// base handler wrapped by NewLogHandler, with an InvocationContext on ctx.
-	// Invoke the default handler directly (rather than through Go) so the
-	// assertion is deterministic and free of goroutine timing.
+func TestRecover_LogsViaSlog(t *testing.T) {
+	// Recover must log the panic at error level through slog so the SDK log
+	// handler can attach invocation metadata. Verify by capturing output.
 	var buf bytes.Buffer
 	base := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})
 	prevDefault := slog.Default()
@@ -137,7 +60,11 @@ func TestDefaultGoroutinePanicHandler_LogsViaSlog(t *testing.T) {
 		TriggerType:  "eventHubTrigger",
 	})
 
-	defaultGoroutinePanicHandler(ctx, "nil pointer-ish", []byte("goroutine 1 [running]:\n..."))
+	// Run Recover via a deferred call that actually panics.
+	func() {
+		defer Recover(ctx)
+		panic("nil pointer-ish")
+	}()
 
 	var rec map[string]any
 	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &rec); err != nil {

--- a/worker/handlers_safego_test.go
+++ b/worker/handlers_safego_test.go
@@ -90,3 +90,43 @@ func TestHandleInvocation_SdkRecover_HappyPath(t *testing.T) {
 
 	waitCh(t, done, "guarded goroutine to complete")
 }
+
+// TestHandleInvocation_SdkRecoverTo_PanicFailsInvocation verifies that a
+// panicking goroutine guarded by sdk.RecoverTo propagates the panic as a
+// failed invocation (Failure status), enabling host retries.
+func TestHandleInvocation_SdkRecoverTo_PanicFailsInvocation(t *testing.T) {
+	disp := newTestDispatcher("req-recoverto-panic")
+
+	handled := make(chan struct{})
+	rf := loadFunc(t, disp, "RecoverToPanic", func(ctx context.Context, _ bindings.TimerInfo) error {
+		// Simulate the errgroup pattern: goroutine panics, RecoverTo
+		// captures it as an error, and the handler returns that error.
+		//
+		// Defer ordering matters: wg.Done is registered first so it runs
+		// LAST (after RecoverTo has set err), ensuring the parent reads
+		// the error only after it's been assigned.
+		var err error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer sdk.RecoverTo(ctx, &err)
+			defer func() { close(handled) }()
+			panic("recoverTo goroutine boom")
+		}()
+		wg.Wait()
+		return err
+	})
+
+	resp, respErr := handleInvocationRequest(invokeRequest(rf.FuncId, "inv-recoverto-panic"), disp, "req-recoverto-panic")
+	if respErr != nil {
+		t.Fatalf("unexpected error: %v", respErr)
+	}
+
+	status := resp.GetInvocationResponse().Result
+	if status.Status != pb.StatusResult_Failure {
+		t.Errorf("expected Failure (panic propagated via RecoverTo), got %v", status.Status)
+	}
+
+	waitCh(t, handled, "RecoverTo goroutine to complete")
+}

--- a/worker/handlers_safego_test.go
+++ b/worker/handlers_safego_test.go
@@ -17,134 +17,34 @@ import (
 func waitCh(t *testing.T, ch <-chan struct{}, what string) {
 	t.Helper()
 	select {
-	case <-ch: // goroutine signaled success
-	case <-time.After(2 * time.Second): // goroutine never finished — fail loud
+	case <-ch:
+	case <-time.After(2 * time.Second):
 		t.Fatalf("timed out waiting for %s", what)
 	}
 }
 
-// TestHandleInvocation_SdkGo_HappyPath verifies that a handler spawning
-// background work via sdk.Go completes successfully and the goroutine
-// runs to completion without crashing the worker.
-func TestHandleInvocation_SdkGo_HappyPath(t *testing.T) {
-	disp := newTestDispatcher("req-safego-ok")
-
-	// The handler fires a background goroutine via sdk.Go that signals done.
-	done := make(chan struct{})
-	rf := loadFunc(t, disp, "SafeGoOK", func(ctx context.Context, _ bindings.TimerInfo) error {
-		sdk.Go(ctx, func() {
-			close(done) // signals the goroutine ran
-		})
-		return nil
-	})
-
-	// Drive the full handleInvocationRequest path — same as the real dispatcher.
-	resp, err := handleInvocationRequest(invokeRequest(rf.FuncId, "inv-safego-ok"), disp, "req-safego-ok")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Handler returned nil, so the invocation must report Success.
-	status := resp.GetInvocationResponse().Result
-	if status.Status != pb.StatusResult_Success {
-		t.Errorf("expected Success, got %v: %v", status.Status, status.Exception)
-	}
-
-	// Confirm the background goroutine actually executed.
-	waitCh(t, done, "sdk.Go goroutine to complete")
-}
-
-// TestHandleInvocation_SdkGo_PanicDoesNotCrashWorker verifies the core
-// guarantee: a panic inside a sdk.Go goroutine is recovered, the
-// invocation itself succeeds (the handler returned nil before the
-// goroutine panicked), and the worker process stays alive.
-func TestHandleInvocation_SdkGo_PanicDoesNotCrashWorker(t *testing.T) {
-	// Swap in a custom panic handler so we can capture the recovered value
-	// without relying on slog output. Restore the default on cleanup.
-	t.Cleanup(func() { sdk.SetGoroutinePanicHandler(nil) })
-
-	var (
-		mu       sync.Mutex
-		gotPanic any
-		handled  = make(chan struct{})
-	)
-	sdk.SetGoroutinePanicHandler(func(_ context.Context, recovered any, _ []byte) {
-		mu.Lock()
-		gotPanic = recovered
-		mu.Unlock()
-		close(handled) // unblock the test once the panic is observed
-	})
-
-	disp := newTestDispatcher("req-safego-panic")
-
-	// The handler spawns a goroutine that panics, but returns nil itself.
-	// Without sdk.Go the panic would tear down the process.
-	rf := loadFunc(t, disp, "SafeGoPanic", func(ctx context.Context, _ bindings.TimerInfo) error {
-		sdk.Go(ctx, func() {
-			panic("background boom")
-		})
-		return nil // handler succeeds; panic is isolated to the goroutine
-	})
-
-	// Run through the real dispatch path.
-	resp, err := handleInvocationRequest(invokeRequest(rf.FuncId, "inv-safego-panic"), disp, "req-safego-panic")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Invocation must succeed — the handler returned nil before the goroutine panicked.
-	status := resp.GetInvocationResponse().Result
-	if status.Status != pb.StatusResult_Success {
-		t.Errorf("expected Success (handler returned nil), got %v: %v", status.Status, status.Exception)
-	}
-
-	// Wait for sdk.Go to recover the panic and route it to our handler.
-	waitCh(t, handled, "panic handler to fire")
-
-	// Verify the correct panic value was captured.
-	mu.Lock()
-	defer mu.Unlock()
-	if gotPanic != "background boom" {
-		t.Errorf("recovered value = %v; want %q", gotPanic, "background boom")
-	}
-}
-
-// TestHandleInvocation_SdkRecover_PanicDoesNotCrashWorker exercises the
-// sdk.Recover path: a handler launches a manual goroutine with
-// defer sdk.Recover(ctx), that goroutine panics, and the worker stays up.
+// TestHandleInvocation_SdkRecover_PanicDoesNotCrashWorker verifies the core
+// guarantee: a handler launches a manual goroutine with defer sdk.Recover(ctx),
+// that goroutine panics, and the worker process stays alive.
 func TestHandleInvocation_SdkRecover_PanicDoesNotCrashWorker(t *testing.T) {
-	// Same custom-handler pattern as the sdk.Go test above.
-	t.Cleanup(func() { sdk.SetGoroutinePanicHandler(nil) })
-
-	var (
-		mu       sync.Mutex
-		gotPanic any
-		handled  = make(chan struct{})
-	)
-	sdk.SetGoroutinePanicHandler(func(_ context.Context, recovered any, _ []byte) {
-		mu.Lock()
-		gotPanic = recovered
-		mu.Unlock()
-		close(handled)
-	})
-
 	disp := newTestDispatcher("req-recover-panic")
 
-	// This handler uses the WaitGroup + defer sdk.Recover pattern from
-	// the README — a manual goroutine rather than sdk.Go.
+	// The handler uses the WaitGroup + defer sdk.Recover pattern.
+	// The goroutine panics, Recover catches it, the handler returns nil.
+	handled := make(chan struct{})
 	rf := loadFunc(t, disp, "RecoverPanic", func(ctx context.Context, _ bindings.TimerInfo) error {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		go func() {
-			defer sdk.Recover(ctx) // catches the panic, keeps the worker alive
-			defer wg.Done()        // unblocks wg.Wait even after a panic
+			defer sdk.Recover(ctx)
+			defer wg.Done()
+			defer func() { close(handled) }()
 			panic("manual goroutine boom")
 		}()
-		wg.Wait() // returns once the goroutine exits (panic recovered)
+		wg.Wait()
 		return nil
 	})
 
-	// Drive the real dispatch path.
 	resp, err := handleInvocationRequest(invokeRequest(rf.FuncId, "inv-recover-panic"), disp, "req-recover-panic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -156,12 +56,37 @@ func TestHandleInvocation_SdkRecover_PanicDoesNotCrashWorker(t *testing.T) {
 		t.Errorf("expected Success (handler returned nil after wg.Wait), got %v: %v", status.Status, status.Exception)
 	}
 
-	// Confirm the panic was routed to our handler, not swallowed silently.
+	// Confirm the goroutine ran (and its panic was recovered, not skipped).
 	waitCh(t, handled, "panic handler to fire from manual goroutine")
+}
 
-	mu.Lock()
-	defer mu.Unlock()
-	if gotPanic != "manual goroutine boom" {
-		t.Errorf("recovered value = %v; want %q", gotPanic, "manual goroutine boom")
+// TestHandleInvocation_SdkRecover_HappyPath verifies that a goroutine
+// guarded by sdk.Recover that does NOT panic completes normally.
+func TestHandleInvocation_SdkRecover_HappyPath(t *testing.T) {
+	disp := newTestDispatcher("req-recover-ok")
+
+	done := make(chan struct{})
+	rf := loadFunc(t, disp, "RecoverOK", func(ctx context.Context, _ bindings.TimerInfo) error {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer sdk.Recover(ctx)
+			defer wg.Done()
+			close(done)
+		}()
+		wg.Wait()
+		return nil
+	})
+
+	resp, err := handleInvocationRequest(invokeRequest(rf.FuncId, "inv-recover-ok"), disp, "req-recover-ok")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
+
+	status := resp.GetInvocationResponse().Result
+	if status.Status != pb.StatusResult_Success {
+		t.Errorf("expected Success, got %v: %v", status.Status, status.Exception)
+	}
+
+	waitCh(t, done, "guarded goroutine to complete")
 }

--- a/worker/handlers_safego_test.go
+++ b/worker/handlers_safego_test.go
@@ -1,0 +1,167 @@
+package worker
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/azure/azure-functions-golang-worker/sdk"
+	"github.com/azure/azure-functions-golang-worker/sdk/bindings"
+	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
+)
+
+// waitCh is a test safety net — it blocks until a channel is closed
+// (signaling a goroutine did its work) or fails the test after 2 seconds
+// so a broken goroutine can't hang the suite forever.
+func waitCh(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch: // goroutine signaled success
+	case <-time.After(2 * time.Second): // goroutine never finished — fail loud
+		t.Fatalf("timed out waiting for %s", what)
+	}
+}
+
+// TestHandleInvocation_SdkGo_HappyPath verifies that a handler spawning
+// background work via sdk.Go completes successfully and the goroutine
+// runs to completion without crashing the worker.
+func TestHandleInvocation_SdkGo_HappyPath(t *testing.T) {
+	disp := newTestDispatcher("req-safego-ok")
+
+	// The handler fires a background goroutine via sdk.Go that signals done.
+	done := make(chan struct{})
+	rf := loadFunc(t, disp, "SafeGoOK", func(ctx context.Context, _ bindings.TimerInfo) error {
+		sdk.Go(ctx, func() {
+			close(done) // signals the goroutine ran
+		})
+		return nil
+	})
+
+	// Drive the full handleInvocationRequest path — same as the real dispatcher.
+	resp, err := handleInvocationRequest(invokeRequest(rf.FuncId, "inv-safego-ok"), disp, "req-safego-ok")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Handler returned nil, so the invocation must report Success.
+	status := resp.GetInvocationResponse().Result
+	if status.Status != pb.StatusResult_Success {
+		t.Errorf("expected Success, got %v: %v", status.Status, status.Exception)
+	}
+
+	// Confirm the background goroutine actually executed.
+	waitCh(t, done, "sdk.Go goroutine to complete")
+}
+
+// TestHandleInvocation_SdkGo_PanicDoesNotCrashWorker verifies the core
+// guarantee: a panic inside a sdk.Go goroutine is recovered, the
+// invocation itself succeeds (the handler returned nil before the
+// goroutine panicked), and the worker process stays alive.
+func TestHandleInvocation_SdkGo_PanicDoesNotCrashWorker(t *testing.T) {
+	// Swap in a custom panic handler so we can capture the recovered value
+	// without relying on slog output. Restore the default on cleanup.
+	t.Cleanup(func() { sdk.SetGoroutinePanicHandler(nil) })
+
+	var (
+		mu       sync.Mutex
+		gotPanic any
+		handled  = make(chan struct{})
+	)
+	sdk.SetGoroutinePanicHandler(func(_ context.Context, recovered any, _ []byte) {
+		mu.Lock()
+		gotPanic = recovered
+		mu.Unlock()
+		close(handled) // unblock the test once the panic is observed
+	})
+
+	disp := newTestDispatcher("req-safego-panic")
+
+	// The handler spawns a goroutine that panics, but returns nil itself.
+	// Without sdk.Go the panic would tear down the process.
+	rf := loadFunc(t, disp, "SafeGoPanic", func(ctx context.Context, _ bindings.TimerInfo) error {
+		sdk.Go(ctx, func() {
+			panic("background boom")
+		})
+		return nil // handler succeeds; panic is isolated to the goroutine
+	})
+
+	// Run through the real dispatch path.
+	resp, err := handleInvocationRequest(invokeRequest(rf.FuncId, "inv-safego-panic"), disp, "req-safego-panic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Invocation must succeed — the handler returned nil before the goroutine panicked.
+	status := resp.GetInvocationResponse().Result
+	if status.Status != pb.StatusResult_Success {
+		t.Errorf("expected Success (handler returned nil), got %v: %v", status.Status, status.Exception)
+	}
+
+	// Wait for sdk.Go to recover the panic and route it to our handler.
+	waitCh(t, handled, "panic handler to fire")
+
+	// Verify the correct panic value was captured.
+	mu.Lock()
+	defer mu.Unlock()
+	if gotPanic != "background boom" {
+		t.Errorf("recovered value = %v; want %q", gotPanic, "background boom")
+	}
+}
+
+// TestHandleInvocation_SdkRecover_PanicDoesNotCrashWorker exercises the
+// sdk.Recover path: a handler launches a manual goroutine with
+// defer sdk.Recover(ctx), that goroutine panics, and the worker stays up.
+func TestHandleInvocation_SdkRecover_PanicDoesNotCrashWorker(t *testing.T) {
+	// Same custom-handler pattern as the sdk.Go test above.
+	t.Cleanup(func() { sdk.SetGoroutinePanicHandler(nil) })
+
+	var (
+		mu       sync.Mutex
+		gotPanic any
+		handled  = make(chan struct{})
+	)
+	sdk.SetGoroutinePanicHandler(func(_ context.Context, recovered any, _ []byte) {
+		mu.Lock()
+		gotPanic = recovered
+		mu.Unlock()
+		close(handled)
+	})
+
+	disp := newTestDispatcher("req-recover-panic")
+
+	// This handler uses the WaitGroup + defer sdk.Recover pattern from
+	// the README — a manual goroutine rather than sdk.Go.
+	rf := loadFunc(t, disp, "RecoverPanic", func(ctx context.Context, _ bindings.TimerInfo) error {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer sdk.Recover(ctx) // catches the panic, keeps the worker alive
+			defer wg.Done()        // unblocks wg.Wait even after a panic
+			panic("manual goroutine boom")
+		}()
+		wg.Wait() // returns once the goroutine exits (panic recovered)
+		return nil
+	})
+
+	// Drive the real dispatch path.
+	resp, err := handleInvocationRequest(invokeRequest(rf.FuncId, "inv-recover-panic"), disp, "req-recover-panic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Handler returned nil after wg.Wait, so invocation must be Success.
+	status := resp.GetInvocationResponse().Result
+	if status.Status != pb.StatusResult_Success {
+		t.Errorf("expected Success (handler returned nil after wg.Wait), got %v: %v", status.Status, status.Exception)
+	}
+
+	// Confirm the panic was routed to our handler, not swallowed silently.
+	waitCh(t, handled, "panic handler to fire from manual goroutine")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotPanic != "manual goroutine boom" {
+		t.Errorf("recovered value = %v; want %q", gotPanic, "manual goroutine boom")
+	}
+}


### PR DESCRIPTION
**Problem**

 The worker only recovers panics that happen synchronously in a handler. A panic in a customer-spawned  go func() { ... }()  runs on a different stack, escapes that  recover, and crashes the entire worker — failing every in-flight invocation with only an opaque "worker exited" error. This is the failure class from a recent  observation in a production app (nil-pointer panic in an EventHub handler's goroutine).

 **Changes**
 •  sdk/safego.go 
   •  Recover(ctx)  — deferrable guard for goroutines you launch yourself (WaitGroup, pool, named func). Logs and swallows the panic, keeping the worker alive.
   •  RecoverTo(ctx, &err)  — deferrable guard that captures the panic as an error via a pointer, so the invocation fails properly and the host can retry. Preserves any      pre-existing error.
 •  sdk/safego_test.go  — stdlib-only unit tests covering both helpers (7 test cases).
 •  worker/handlers_safego_test.go  — integration tests verifying the worker stays alive after a panicking goroutine.
 •  README.md  — new "Goroutine safety & panic recovery" section with  RecoverTo  and  Recover  usage examples.

 **Notes**

 • Panics are logged with full stack + invocation metadata; worker stays up.
 • Both helpers document that they must be the first  defer  (LIFO ordering ensures they run last and catch everything).
 • Stdlib-only, opt-in.

How this error propagates:
<img width="2800" height="355" alt="image" src="https://github.com/user-attachments/assets/944f8813-23c1-4214-9a02-bb14c7dd3041" />

```
recovered panic in goroutine trigger_type=httpTrigger panic="runtime error: invalid memory address or nil pointer dereference" stack="goroutine 45 [running]:\nruntime/debug.Stack()\n\tC:/Program Files/Go/src/runtime/debug/stack.go:26 +0x5e\ngithub.com/azure/azure-functions-golang-worker/sdk.RecoverTo({0xafce10, 0x35b4d94ef3b0}, 0x35b4d9225f20)\n\tC:/Users/hakkaraj/Workspace/azure-functions-golang-worker/sdk/safego.go:92 +0x3e\npanic({0x9f4160?, 0xffc020?})\n\tC:/Program Files/Go/src/runtime/panic.go:860 +0x13a\nmain.RecoverToHandler.func1()\n\tC:/Users/hakkaraj/Workspace/azure-functions-golang-worker/samples/recoverTo/main.go:33 +0x63\ngolang.org/x/sync/errgroup.(*Group).Go.func1()\n\tC:/Users/hakkaraj/go/pkg/mod/golang.org/x/sync@v0.19.0/errgroup/errgroup.go:93 +0x50\ncreated by golang.org/x/sync/errgroup.(*Group).Go in goroutine 4\n\tC:/Users/hakkaraj/go/pkg/mod/golang.org/x/sync@v0.19.0/errgroup/errgroup.go:78 +0x95\n"
```