### PR TITLE
Add Azure Storage Queue Trigger Support

### DIFF
--- a/middleware/otelfunc/go.sum
+++ b/middleware/otelfunc/go.sum
@@ -1,3 +1,5 @@
+github.com/azure/azure-functions-golang-worker v0.6.0-preview h1:sSXuTZCdVStX0O0TDYpb3EB8iGS1DYQi+p5W9aaQuBE=
+github.com/azure/azure-functions-golang-worker v0.6.0-preview/go.mod h1:jkzgeVs8oQqxoR0keXFrcBMqN288Bidzkaf+RAuk1OQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/middleware/otelfunc/middleware.go
+++ b/middleware/otelfunc/middleware.go
@@ -737,11 +737,11 @@ func classifyTrigger(t string) string {
 		return "http"
 	case "timerTrigger":
 		return "timer"
-	case "blobTrigger", "cosmosDBTrigger":
+	case "blobTrigger", "cosmosDBTrigger", "sqlTrigger":
 		return "datasource"
 	case "eventHubTrigger", "serviceBusTrigger",
 		"serviceBusQueueTrigger", "serviceBusTopicTrigger",
-		"eventGridTrigger":
+		"eventGridTrigger", "queueTrigger":
 		return "pubsub"
 	default:
 		return "other"

--- a/middleware/otelfunc/middleware_test.go
+++ b/middleware/otelfunc/middleware_test.go
@@ -295,11 +295,13 @@ func TestClassifyTrigger(t *testing.T) {
 		"timerTrigger":           "timer",
 		"blobTrigger":            "datasource",
 		"cosmosDBTrigger":        "datasource",
+		"sqlTrigger":             "datasource",
 		"eventHubTrigger":        "pubsub",
 		"serviceBusTrigger":      "pubsub",
 		"serviceBusQueueTrigger": "pubsub",
 		"serviceBusTopicTrigger": "pubsub",
 		"eventGridTrigger":       "pubsub",
+		"queueTrigger":           "pubsub",
 		"":                       "other",
 		"someUnknownTriggerType": "other",
 	}

--- a/samples/queueTrigger/README.md
+++ b/samples/queueTrigger/README.md
@@ -1,0 +1,42 @@
+# Queue Storage Trigger Sample
+
+Demonstrates an Azure Storage Queue triggered function in Go.
+
+## Prerequisites
+
+- [Go 1.24+](https://go.dev/dl/)
+- [Azure Functions Core Tools v4.12.0+](https://www.npmjs.com/package/azure-functions-core-tools)
+- [Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite) (local storage emulator)
+
+## Running Locally
+
+1. Start Azurite (or use the docker-compose in `tests/emulators/`):
+
+   ```bash
+   docker compose -f tests/emulators/docker-compose.yml up azurite -d
+   ```
+
+2. Start the function app:
+
+   ```bash
+   cd samples/queueTrigger
+   func start
+   ```
+
+3. Send a message to the queue using Azure Storage Explorer, `az` CLI, or the Azure SDK:
+
+   ```bash
+   az storage message put \
+     --queue-name myqueue \
+     --content "Hello from Storage Queue!" \
+     --connection-string "UseDevelopmentStorage=true"
+   ```
+
+4. Observe the function trigger in the console output with message metadata.
+
+## Configuration
+
+| Option | Description |
+|--------|-------------|
+| `sdk.WithQueueName("myqueue")` | The name of the Azure Storage Queue to monitor |
+| `sdk.WithConnection("AzureWebJobsStorage")` | App setting name containing the storage connection string |

--- a/samples/queueTrigger/README.md
+++ b/samples/queueTrigger/README.md
@@ -40,3 +40,17 @@ Demonstrates an Azure Storage Queue triggered function in Go.
 |--------|-------------|
 | `sdk.WithQueueName("myqueue")` | The name of the Azure Storage Queue to monitor |
 | `sdk.WithConnection("AzureWebJobsStorage")` | App setting name containing the storage connection string |
+
+## Message Encoding
+
+The `host.json` in this sample sets `"messageEncoding": "none"` under `extensions.queues`. This tells the host to pass message bodies as-is without Base64 encoding/decoding. If your messages are Base64-encoded (the Azure Functions default), remove this setting or set it to `"base64"`.
+
+```json
+{
+  "extensions": {
+    "queues": {
+      "messageEncoding": "none"
+    }
+  }
+}
+```

--- a/samples/queueTrigger/host.json
+++ b/samples/queueTrigger/host.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/samples/queueTrigger/host.json
+++ b/samples/queueTrigger/host.json
@@ -1,5 +1,10 @@
 {
   "version": "2.0",
+  "extensions": {
+    "queues": {
+      "messageEncoding": "none"
+    }
+  },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[4.*, 5.0.0)"

--- a/samples/queueTrigger/host.json
+++ b/samples/queueTrigger/host.json
@@ -1,10 +1,5 @@
 {
   "version": "2.0",
-  "extensions": {
-    "queues": {
-      "messageEncoding": "none"
-    }
-  },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[4.*, 5.0.0)"

--- a/samples/queueTrigger/local.settings.json
+++ b/samples/queueTrigger/local.settings.json
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "native"
+  }
+}

--- a/samples/queueTrigger/local.settings.json
+++ b/samples/queueTrigger/local.settings.json
@@ -2,6 +2,7 @@
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "FUNCTIONS_WORKER_RUNTIME": "native"
+    "FUNCTIONS_WORKER_RUNTIME": "native",
+    "FUNCTIONS_CLI_NATIVE_LANGUAGE": "go"
   }
 }

--- a/samples/queueTrigger/main.go
+++ b/samples/queueTrigger/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/azure/azure-functions-golang-worker/sdk"
+	"github.com/azure/azure-functions-golang-worker/sdk/bindings"
+	"github.com/azure/azure-functions-golang-worker/worker"
+)
+
+// QueueHandler handles messages from an Azure Storage Queue.
+func QueueHandler(ctx context.Context, msg bindings.QueueMessage) error {
+	slog.InfoContext(ctx, "queue trigger executed",
+		"id", msg.Id,
+		"body", string(msg.Body),
+		"dequeue_count", msg.DequeueCount,
+		"pop_receipt", msg.PopReceipt,
+		"insertion_time", msg.InsertionTime,
+		"expiration_time", msg.ExpirationTime,
+		"next_visible_time", msg.NextVisibleTime,
+	)
+	return nil
+}
+
+func main() {
+	app := sdk.FunctionApp()
+
+	app.Queue("queueFunc", QueueHandler,
+		sdk.WithQueueName("myqueue"),
+		sdk.WithConnection("AzureWebJobsStorage"),
+	)
+
+	worker.Start(app)
+}

--- a/samples/queueTrigger/main.go
+++ b/samples/queueTrigger/main.go
@@ -17,6 +17,7 @@ func QueueHandler(ctx context.Context, msg bindings.QueueMessage) error {
 		"dequeue_count", msg.DequeueCount,
 		"pop_receipt", msg.PopReceipt,
 		"expiration_time", msg.ExpirationTime,
+		"insertion_time", msg.InsertionTime,
 		"next_visible_time", msg.NextVisibleTime,
 	)
 	return nil

--- a/samples/queueTrigger/main.go
+++ b/samples/queueTrigger/main.go
@@ -16,7 +16,6 @@ func QueueHandler(ctx context.Context, msg bindings.QueueMessage) error {
 		"body", string(msg.Body),
 		"dequeue_count", msg.DequeueCount,
 		"pop_receipt", msg.PopReceipt,
-		"insertion_time", msg.InsertionTime,
 		"expiration_time", msg.ExpirationTime,
 		"next_visible_time", msg.NextVisibleTime,
 	)

--- a/sdk/app.go
+++ b/sdk/app.go
@@ -98,6 +98,14 @@ func (app *App) EventGrid(name string, f EventGridHandler, opts ...Option) *Regi
 	return app.registerFunction(name, f, trigger, opts...)
 }
 
+// Queue creates a new Azure Storage Queue triggered function.
+func (app *App) Queue(name string, f QueueHandler, opts ...Option) *RegisteredFunction {
+	trigger := &bindings.QueueStorageTrigger{
+		Name: "message",
+	}
+	return app.registerFunction(name, f, trigger, opts...)
+}
+
 // EventHub creates a new EventHub triggered function.
 func (app *App) EventHub(name string, f EventHubHandler, opts ...Option) *RegisteredFunction {
 	trigger := &bindings.EventHubTrigger{

--- a/sdk/app_test.go
+++ b/sdk/app_test.go
@@ -955,3 +955,74 @@ func TestSQL_WithLeasesTable(t *testing.T) {
 		return true
 	})
 }
+
+// --- Queue Storage tests ---
+
+func TestQueue_BasicRegistration(t *testing.T) {
+	app := FunctionApp()
+	handler := QueueHandler(func(ctx context.Context, msg bindings.QueueMessage) error {
+		return nil
+	})
+
+	rf := app.Queue("processQueue", handler,
+		WithQueueName("myqueue"),
+		WithConnection("AzureWebJobsStorage"),
+	)
+
+	if rf == nil {
+		t.Fatal("expected non-nil RegisteredFunction")
+	}
+	if rf.FuncName != "processQueue" {
+		t.Errorf("expected FuncName %q, got %q", "processQueue", rf.FuncName)
+	}
+	if rf.TriggerType != "queueTrigger" {
+		t.Errorf("expected TriggerType %q, got %q", "queueTrigger", rf.TriggerType)
+	}
+}
+
+func TestQueue_Options(t *testing.T) {
+	app := FunctionApp()
+	handler := QueueHandler(func(ctx context.Context, msg bindings.QueueMessage) error {
+		return nil
+	})
+
+	app.Queue("queueFunc", handler,
+		WithQueueName("testqueue"),
+		WithConnection("StorageConn"),
+	)
+
+	app.GetRegisteredFunctions().Range(func(key, value any) bool {
+		rf := value.(*RegisteredFunction)
+		binding := rf.RawBindings[0]
+		if binding.QueueBinding == nil {
+			t.Fatal("expected QueueBinding")
+		}
+		if binding.QueueBinding.QueueName != "testqueue" {
+			t.Errorf("expected queueName %q, got %q", "testqueue", binding.QueueBinding.QueueName)
+		}
+		if binding.QueueBinding.Connection != "StorageConn" {
+			t.Errorf("expected connection %q, got %q", "StorageConn", binding.QueueBinding.Connection)
+		}
+		return true
+	})
+}
+
+func TestQueue_NoOutputBindings(t *testing.T) {
+	app := FunctionApp()
+	handler := QueueHandler(func(ctx context.Context, msg bindings.QueueMessage) error {
+		return nil
+	})
+
+	app.Queue("queueNoOutput", handler,
+		WithQueueName("q1"),
+		WithConnection("Conn"),
+	)
+
+	app.GetRegisteredFunctions().Range(func(key, value any) bool {
+		rf := value.(*RegisteredFunction)
+		if len(rf.RawBindings) != 1 {
+			t.Errorf("expected 1 binding (trigger only, no $return), got %d", len(rf.RawBindings))
+		}
+		return true
+	})
+}

--- a/sdk/bindings/common.go
+++ b/sdk/bindings/common.go
@@ -28,6 +28,7 @@ type Binding struct {
 	*EventHubBinding
 	*ServiceBusBinding
 	*SQLBinding
+	*QueueBinding
 }
 
 // MarshalJSON flattens the embedded sub-binding fields into the top-level
@@ -55,6 +56,8 @@ func (b Binding) MarshalJSON() ([]byte, error) {
 		sub = b.ServiceBusBinding
 	} else if b.SQLBinding != nil {
 		sub = b.SQLBinding
+	} else if b.QueueBinding != nil {
+		sub = b.QueueBinding
 	}
 
 	if sub != nil {

--- a/sdk/bindings/queue.go
+++ b/sdk/bindings/queue.go
@@ -1,0 +1,50 @@
+package bindings
+
+import "encoding/json"
+
+// QueueTriggerType is the binding type constant for Azure Storage Queue triggers.
+const QueueTriggerType BindingType = "queueTrigger"
+
+// QueueBinding is the JSON representation for Storage Queue bindings.
+type QueueBinding struct {
+	QueueName  string `json:"queueName,omitempty"`
+	Connection string `json:"connection,omitempty"`
+}
+
+// QueueStorageTrigger is the user-facing configuration for a Storage Queue trigger.
+type QueueStorageTrigger struct {
+	Name       string
+	QueueName  string
+	Connection string
+}
+
+// GetBindingType returns the Storage Queue trigger binding type.
+func (q *QueueStorageTrigger) GetBindingType() BindingType { return QueueTriggerType }
+
+// ToBinding converts the QueueStorageTrigger to a Binding.
+func (q *QueueStorageTrigger) ToBinding() Binding {
+	return Binding{
+		Name:      q.Name,
+		Type:      string(q.GetBindingType()),
+		Direction: "in",
+		QueueBinding: &QueueBinding{
+			QueueName:  q.QueueName,
+			Connection: q.Connection,
+		},
+	}
+}
+
+// QueueMessage represents a message received from Azure Storage Queue.
+// The Body field uses the special json tag "azfuncdata" which instructs the
+// worker's converter to populate this field from the raw trigger input data
+// rather than from trigger metadata. Other fields are populated from trigger
+// metadata using case-insensitive matching on their json tags.
+type QueueMessage struct {
+	Body            json.RawMessage `json:"azfuncdata"`
+	Id              string          `json:"id"`
+	PopReceipt      string          `json:"popReceipt"`
+	DequeueCount    int64           `json:"dequeueCount"`
+	ExpirationTime  string          `json:"expirationTime"`
+	InsertionTime   string          `json:"insertionTime"`
+	NextVisibleTime string          `json:"nextVisibleTime"`
+}

--- a/sdk/bindings/queue.go
+++ b/sdk/bindings/queue.go
@@ -45,6 +45,5 @@ type QueueMessage struct {
 	PopReceipt      string          `json:"popReceipt"`
 	DequeueCount    int64           `json:"dequeueCount"`
 	ExpirationTime  string          `json:"expirationTime"`
-	InsertionTime   string          `json:"insertionTime"`
 	NextVisibleTime string          `json:"nextVisibleTime"`
 }

--- a/sdk/bindings/queue.go
+++ b/sdk/bindings/queue.go
@@ -45,5 +45,6 @@ type QueueMessage struct {
 	PopReceipt      string          `json:"popReceipt"`
 	DequeueCount    int64           `json:"dequeueCount"`
 	ExpirationTime  string          `json:"expirationTime"`
+	InsertionTime   string          `json:"insertionTime"`
 	NextVisibleTime string          `json:"nextVisibleTime"`
 }

--- a/sdk/bindings/queue_test.go
+++ b/sdk/bindings/queue_test.go
@@ -77,7 +77,6 @@ func TestQueueMessage_JSON(t *testing.T) {
 		PopReceipt:     "receipt-abc",
 		DequeueCount:   3,
 		ExpirationTime: "2026-07-01T00:00:00Z",
-		InsertionTime:  "2026-06-22T10:00:00Z",
 	}
 
 	data, err := json.Marshal(msg)

--- a/sdk/bindings/queue_test.go
+++ b/sdk/bindings/queue_test.go
@@ -1,0 +1,102 @@
+package bindings
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestQueueStorageTrigger_ToBinding(t *testing.T) {
+	trigger := &QueueStorageTrigger{
+		Name:       "message",
+		QueueName:  "myqueue",
+		Connection: "AzureWebJobsStorage",
+	}
+
+	binding := trigger.ToBinding()
+
+	if binding.Type != "queueTrigger" {
+		t.Errorf("expected type %q, got %q", "queueTrigger", binding.Type)
+	}
+	if binding.Direction != "in" {
+		t.Errorf("expected direction %q, got %q", "in", binding.Direction)
+	}
+	if binding.QueueBinding == nil {
+		t.Fatal("expected QueueBinding")
+	}
+	if binding.QueueBinding.QueueName != "myqueue" {
+		t.Errorf("expected queueName %q, got %q", "myqueue", binding.QueueBinding.QueueName)
+	}
+	if binding.QueueBinding.Connection != "AzureWebJobsStorage" {
+		t.Errorf("expected connection %q, got %q", "AzureWebJobsStorage", binding.QueueBinding.Connection)
+	}
+}
+
+func TestQueueStorageTrigger_GetBindingType(t *testing.T) {
+	trigger := &QueueStorageTrigger{Name: "msg"}
+	if trigger.GetBindingType() != QueueTriggerType {
+		t.Errorf("expected %q, got %q", QueueTriggerType, trigger.GetBindingType())
+	}
+}
+
+func TestQueueStorageTrigger_MarshalJSON(t *testing.T) {
+	trigger := &QueueStorageTrigger{
+		Name:       "message",
+		QueueName:  "testqueue",
+		Connection: "StorageConn",
+	}
+
+	binding := trigger.ToBinding()
+	data, err := json.Marshal(binding)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if m["type"] != "queueTrigger" {
+		t.Errorf("expected type %q, got %v", "queueTrigger", m["type"])
+	}
+	if m["direction"] != "in" {
+		t.Errorf("expected direction %q, got %v", "in", m["direction"])
+	}
+	if m["queueName"] != "testqueue" {
+		t.Errorf("expected queueName %q, got %v", "testqueue", m["queueName"])
+	}
+	if m["connection"] != "StorageConn" {
+		t.Errorf("expected connection %q, got %v", "StorageConn", m["connection"])
+	}
+}
+
+func TestQueueMessage_JSON(t *testing.T) {
+	msg := QueueMessage{
+		Body:           json.RawMessage(`"hello world"`),
+		Id:             "msg-456",
+		PopReceipt:     "receipt-abc",
+		DequeueCount:   3,
+		ExpirationTime: "2026-07-01T00:00:00Z",
+		InsertionTime:  "2026-06-22T10:00:00Z",
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var decoded QueueMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if decoded.Id != "msg-456" {
+		t.Errorf("expected id %q, got %q", "msg-456", decoded.Id)
+	}
+	if decoded.PopReceipt != "receipt-abc" {
+		t.Errorf("expected popReceipt %q, got %q", "receipt-abc", decoded.PopReceipt)
+	}
+	if decoded.DequeueCount != 3 {
+		t.Errorf("expected dequeueCount %d, got %d", 3, decoded.DequeueCount)
+	}
+}

--- a/sdk/bindings/queue_test.go
+++ b/sdk/bindings/queue_test.go
@@ -77,6 +77,7 @@ func TestQueueMessage_JSON(t *testing.T) {
 		PopReceipt:     "receipt-abc",
 		DequeueCount:   3,
 		ExpirationTime: "2026-07-01T00:00:00Z",
+		InsertionTime:  "2026-06-22T18:57:34Z",
 	}
 
 	data, err := json.Marshal(msg)
@@ -97,5 +98,8 @@ func TestQueueMessage_JSON(t *testing.T) {
 	}
 	if decoded.DequeueCount != 3 {
 		t.Errorf("expected dequeueCount %d, got %d", 3, decoded.DequeueCount)
+	}
+	if decoded.InsertionTime != "2026-06-22T18:57:34Z" {
+		t.Errorf("expected insertionTime %q, got %q", "2026-06-22T18:57:34Z", decoded.InsertionTime)
 	}
 }

--- a/sdk/handlers.go
+++ b/sdk/handlers.go
@@ -50,6 +50,9 @@ type SQLChangeHandler = func(context.Context, []bindings.SQLChange) error
 // EventGridHandler is the handler type for Event Grid triggered functions.
 type EventGridHandler = func(context.Context, bindings.EventGridEvent) error
 
+// QueueHandler is the handler type for Azure Storage Queue triggered functions.
+type QueueHandler = func(context.Context, bindings.QueueMessage) error
+
 // BlobHandler is the handler type for blob triggered functions that receive
 // the blob content as raw bytes. For large blobs or SDK-type blob client
 // access, use the triggers/blob module instead.

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -82,7 +82,7 @@ func WithConsumerGroup(group string) Option {
 	}
 }
 
-// --- ServiceBus Queue-specific options ---
+// --- Queue-specific options (Service Bus + Storage Queue) ---
 
 // WithQueueName sets the queue name for a Service Bus queue trigger or
 // a Storage Queue trigger.

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -84,11 +84,17 @@ func WithConsumerGroup(group string) Option {
 
 // --- ServiceBus Queue-specific options ---
 
-// WithQueueName sets the Service Bus queue name.
+// WithQueueName sets the queue name for a Service Bus queue trigger or
+// a Storage Queue trigger.
 func WithQueueName(queueName string) Option {
 	return func(rf *RegisteredFunction) {
-		if b := rf.triggerBinding(); b != nil && b.ServiceBusBinding != nil {
-			b.ServiceBusBinding.QueueName = queueName
+		if b := rf.triggerBinding(); b != nil {
+			if b.ServiceBusBinding != nil {
+				b.ServiceBusBinding.QueueName = queueName
+			}
+			if b.QueueBinding != nil {
+				b.QueueBinding.QueueName = queueName
+			}
 		}
 	}
 }
@@ -185,6 +191,9 @@ func WithConnection(connection string) Option {
 		}
 		if b.BlobBinding != nil {
 			b.BlobBinding.Connection = connection
+		}
+		if b.QueueBinding != nil {
+			b.QueueBinding.Connection = connection
 		}
 		if b.SQLBinding != nil {
 			b.SQLBinding.ConnectionStringSetting = connection

--- a/tests/integration/go.mod
+++ b/tests/integration/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs v1.3.1
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1
 	github.com/microsoft/go-mssqldb v1.10.0
 )
 
@@ -14,7 +15,6 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1 // indirect
 	github.com/Azure/go-amqp v1.4.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect

--- a/tests/integration/go.mod
+++ b/tests/integration/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1 // indirect
 	github.com/Azure/go-amqp v1.4.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect

--- a/tests/integration/go.sum
+++ b/tests/integration/go.sum
@@ -22,6 +22,8 @@ github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfg
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 h1:jWQK1GI+LeGGUKBADtcH2rRqPxYB1Ljwms5gFA2LqrM=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4/go.mod h1:8mwH4klAm9DUgR2EEHyEEAQlRDvLPyg5fQry3y+cDew=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1 h1:qvrrnQ2mIjwY7IVlQuNB0ma43Nr74+9ZTZJ60KlmlV4=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1/go.mod h1:FkF/Az07vR3S4sBdjCuisznWfFWOD8u6Ibm/g/oyDAk=
 github.com/Azure/go-amqp v1.4.0 h1:Xj3caqi4comOF/L1Uc5iuBxR/pB6KumejC01YQOqOR4=
 github.com/Azure/go-amqp v1.4.0/go.mod h1:vZAogwdrkbyK3Mla8m/CxSc/aKdnTZ4IbPxl51Y5WZE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=

--- a/tests/integration/queue_storage_test.go
+++ b/tests/integration/queue_storage_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 var queueStorageEnv = map[string]string{
-	"AzureWebJobsStorage":      azuriteConnStr,
-	"FUNCTIONS_WORKER_RUNTIME": "native",
+	"AzureWebJobsStorage":            azuriteConnStr,
+	"FUNCTIONS_WORKER_RUNTIME":       "native",
+	"FUNCTIONS_CLI_NATIVE_LANGUAGE":  "go",
 }
 
 func TestQueueStorageTriggerFires(t *testing.T) {
@@ -43,17 +44,19 @@ func TestQueueStorageTriggerMetadata(t *testing.T) {
 	proc.AssertLogContains("metadata-test-message", 5*time.Second)
 }
 
-// ensureQueue creates the queue in Azurite if it doesn't already exist.
+// ensureQueue deletes any existing queue (clearing stale messages) and
+// recreates it fresh for the test.
 func ensureQueue(t *testing.T, queueName string) {
 	t.Helper()
 	client, err := azqueue.NewServiceClientFromConnectionString(azuriteConnStr, nil)
 	if err != nil {
 		t.Fatalf("failed to create queue service client: %v", err)
 	}
+	// Delete first to clear stale messages from prior runs
+	_, _ = client.DeleteQueue(context.Background(), queueName, nil)
 	_, err = client.CreateQueue(context.Background(), queueName, nil)
 	if err != nil {
-		// Ignore "queue already exists" errors
-		t.Logf("create queue %q (may already exist): %v", queueName, err)
+		t.Fatalf("failed to create queue %q: %v", queueName, err)
 	}
 }
 

--- a/tests/integration/queue_storage_test.go
+++ b/tests/integration/queue_storage_test.go
@@ -1,0 +1,72 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+)
+
+var queueStorageEnv = map[string]string{
+	"AzureWebJobsStorage":      azuriteConnStr,
+	"FUNCTIONS_WORKER_RUNTIME": "native",
+}
+
+func TestQueueStorageTriggerFires(t *testing.T) {
+	requireAzurite(t)
+
+	// Create the queue in Azurite before starting the host
+	ensureQueue(t, "myqueue")
+
+	proc := StartFuncHost(t, "queueTrigger", 7210, queueStorageEnv, 30*time.Second)
+
+	// Enqueue a message
+	enqueueMessage(t, "myqueue", "Hello from queue storage integration test!")
+
+	proc.AssertLogContains("queue trigger executed", 15*time.Second)
+	proc.AssertLogContains("Succeeded", 5*time.Second)
+}
+
+func TestQueueStorageTriggerMetadata(t *testing.T) {
+	requireAzurite(t)
+
+	ensureQueue(t, "myqueue")
+
+	proc := StartFuncHost(t, "queueTrigger", 7211, queueStorageEnv, 30*time.Second)
+
+	enqueueMessage(t, "myqueue", "metadata-test-message")
+
+	// Verify metadata fields are populated (logged by the sample handler)
+	proc.AssertLogContains("queue trigger executed", 15*time.Second)
+	proc.AssertLogContains("metadata-test-message", 5*time.Second)
+}
+
+// ensureQueue creates the queue in Azurite if it doesn't already exist.
+func ensureQueue(t *testing.T, queueName string) {
+	t.Helper()
+	client, err := azqueue.NewServiceClientFromConnectionString(azuriteConnStr, nil)
+	if err != nil {
+		t.Fatalf("failed to create queue service client: %v", err)
+	}
+	_, err = client.CreateQueue(context.Background(), queueName, nil)
+	if err != nil {
+		// Ignore "queue already exists" errors
+		t.Logf("create queue %q (may already exist): %v", queueName, err)
+	}
+}
+
+// enqueueMessage sends a message to the specified queue.
+func enqueueMessage(t *testing.T, queueName, body string) {
+	t.Helper()
+	client, err := azqueue.NewServiceClientFromConnectionString(azuriteConnStr, nil)
+	if err != nil {
+		t.Fatalf("failed to create queue service client: %v", err)
+	}
+	queueClient := client.NewQueueClient(queueName)
+	_, err = queueClient.EnqueueMessage(context.Background(), fmt.Sprintf("%s", body), nil)
+	if err != nil {
+		t.Fatalf("failed to enqueue message: %v", err)
+	}
+}

--- a/tests/integration/queue_storage_test.go
+++ b/tests/integration/queue_storage_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -10,9 +9,9 @@ import (
 )
 
 var queueStorageEnv = map[string]string{
-	"AzureWebJobsStorage":            azuriteConnStr,
-	"FUNCTIONS_WORKER_RUNTIME":       "native",
-	"FUNCTIONS_CLI_NATIVE_LANGUAGE":  "go",
+	"AzureWebJobsStorage":           azuriteConnStr,
+	"FUNCTIONS_WORKER_RUNTIME":      "native",
+	"FUNCTIONS_CLI_NATIVE_LANGUAGE": "go",
 }
 
 func TestQueueStorageTriggerFires(t *testing.T) {
@@ -68,7 +67,7 @@ func enqueueMessage(t *testing.T, queueName, body string) {
 		t.Fatalf("failed to create queue service client: %v", err)
 	}
 	queueClient := client.NewQueueClient(queueName)
-	_, err = queueClient.EnqueueMessage(context.Background(), fmt.Sprintf("%s", body), nil)
+	_, err = queueClient.EnqueueMessage(context.Background(), body, nil)
 	if err != nil {
 		t.Fatalf("failed to enqueue message: %v", err)
 	}

--- a/worker/converter.go
+++ b/worker/converter.go
@@ -41,6 +41,36 @@ func FromProto(req *pb.InvocationRequest, fields map[string]*funcField, args []r
 	return nil
 }
 
+// azFuncDataTag is the special json struct-field tag used by SDK binding
+// types (e.g. QueueMessage, ServiceBusMessage) to mark the single field
+// that should receive the raw trigger input body. All other fields on
+// such a struct are populated from trigger metadata, looked up by name.
+const azFuncDataTag = "azfuncdata"
+
+// isAzFuncDataField reports whether field f opts into azFuncDataTag.
+// Matching is case-insensitive and tolerates options like ",omitempty".
+func isAzFuncDataField(f reflect.StructField) bool {
+	tag := f.Tag.Get("json")
+	if idx := strings.Index(tag, ","); idx != -1 {
+		tag = tag[:idx]
+	}
+	return strings.EqualFold(tag, azFuncDataTag)
+}
+
+// hasAzFuncDataField reports whether the struct type t declares any field
+// tagged with azFuncDataTag. Structs that opt into this tag use a single
+// field to hold the raw input body while other fields are populated from
+// trigger metadata, and must NOT be decoded via whole-struct json.Unmarshal
+// of the body.
+func hasAzFuncDataField(t reflect.Type) bool {
+	for i := 0; i < t.NumField(); i++ {
+		if isAzFuncDataField(t.Field(i)) {
+			return true
+		}
+	}
+	return false
+}
+
 // convertToTypeValue returns a native value from protobuf
 func convertToTypeValue(pt reflect.Type, data *pb.TypedData, tm map[string]*pb.TypedData) (reflect.Value, error) {
 	var t reflect.Type
@@ -53,8 +83,17 @@ func convertToTypeValue(pt reflect.Type, data *pb.TypedData, tm map[string]*pb.T
 	pv := reflect.New(t)
 	v := pv.Elem()
 
-	// If struct, try JSON decoding first, then fall back to TriggerMetadata field matching
-	if t.Kind() == reflect.Struct {
+	// If struct, try JSON decoding first, then fall back to TriggerMetadata field matching.
+	//
+	// Skip the whole-struct JSON fast-path when the struct declares an
+	// "azfuncdata"-tagged field: that tag signals the input body belongs
+	// in that single field (e.g. QueueMessage.Body, ServiceBusMessage.Body),
+	// not unmarshalled across the whole struct. Without this guard, a queue
+	// message with a JSON object body would silently produce a zero-valued
+	// QueueMessage — the unmarshal succeeds but matches no field tags, the
+	// fast path returns, and the per-field "azfuncdata" + metadata fallback
+	// below is never reached.
+	if t.Kind() == reflect.Struct && !hasAzFuncDataField(t) {
 		// Try direct JSON unmarshal from input data (TypedData_Json or TypedData_String_)
 		jsonStr := data.GetJson()
 		if jsonStr == "" {
@@ -72,35 +111,39 @@ func convertToTypeValue(pt reflect.Type, data *pb.TypedData, tm map[string]*pb.T
 				return val, nil
 			}
 		}
+	}
 
+	if t.Kind() == reflect.Struct {
 		// Fall back to field-by-field matching from TriggerMetadata
 		fieldsDecoded := 0
 		for i := 0; i < v.NumField(); i++ {
 			field := t.Field(i)
-			tag := field.Tag.Get("json")
-			// Strip omitempty or other options from the json tag
-			if idx := strings.Index(tag, ","); idx != -1 {
-				tag = tag[:idx]
-			}
 
 			var td *pb.TypedData
-			if strings.EqualFold(tag, "azfuncdata") {
+			if isAzFuncDataField(field) {
 				td = data
 				fieldsDecoded++
-			} else if val, ok := tm[tag]; ok {
-				td = val
-				fieldsDecoded++
 			} else {
-				// Case-insensitive fallback
-				for k, val := range tm {
-					if strings.EqualFold(k, tag) {
-						td = val
-						fieldsDecoded++
-						break
-					}
+				tag := field.Tag.Get("json")
+				// Strip omitempty or other options from the json tag
+				if idx := strings.Index(tag, ","); idx != -1 {
+					tag = tag[:idx]
 				}
-				if td == nil {
-					continue
+				if val, ok := tm[tag]; ok {
+					td = val
+					fieldsDecoded++
+				} else {
+					// Case-insensitive fallback
+					for k, val := range tm {
+						if strings.EqualFold(k, tag) {
+							td = val
+							fieldsDecoded++
+							break
+						}
+					}
+					if td == nil {
+						continue
+					}
 				}
 			}
 

--- a/worker/converter.go
+++ b/worker/converter.go
@@ -137,6 +137,29 @@ func convertToTypeValue(pt reflect.Type, data *pb.TypedData, tm map[string]*pb.T
 	return d, nil
 }
 
+// decodeProto converts a single TypedData value from the host into a Go
+// reflect.Value of the requested type t. It is called per-field when
+// populating struct-based trigger messages (e.g. ServiceBusMessage,
+// QueueMessage) from trigger metadata, and also for scalar argument types.
+//
+// TypedData is a protobuf oneof — the host extension chooses which variant
+// to populate (String_, Json, Bytes, Int, Double, Http). Different
+// extensions make different choices for the same logical data type:
+//
+//   - ServiceBus sends time fields as TypedData_String_ ("2026-06-22T...")
+//   - Storage Queues sends time fields as TypedData_Json ("\"2026-06-22T...\"")
+//   - DequeueCount comes as TypedData_Json (bare number: 1) not TypedData_Int
+//
+// The decoding strategy is:
+//  1. Try the "natural" TypedData variant for the target Go type (e.g.
+//     String_ for string, Int for int64, Bytes for []byte).
+//  2. If the natural variant is empty/zero, fall through to the generic
+//     fallback paths at the bottom of the function (JSON unmarshal,
+//     string-to-T conversion, bytes-to-T).
+//
+// This two-phase approach ensures backward compatibility — triggers that
+// already work with TypedData_String_ keep working — while also handling
+// extensions that send values via a different variant.
 func decodeProto(data *pb.TypedData, t reflect.Type) (reflect.Value, error) {
 	if data == nil {
 		return reflect.Zero(t), nil
@@ -144,7 +167,10 @@ func decodeProto(data *pb.TypedData, t reflect.Type) (reflect.Value, error) {
 
 	switch t.Kind() {
 	case reflect.String:
-		return reflect.ValueOf(data.GetString_()), nil
+		if s := data.GetString_(); s != "" {
+			return reflect.ValueOf(s), nil
+		}
+		// Fall through to JSON/bytes handling below when String_ is empty
 	case reflect.Bool:
 		if val := data.GetString_(); val != "" {
 			return reflect.ValueOf(strings.EqualFold(val, "true")), nil

--- a/worker/converter.go
+++ b/worker/converter.go
@@ -178,13 +178,16 @@ func decodeProto(data *pb.TypedData, t reflect.Type) (reflect.Value, error) {
 		return reflect.ValueOf(data.GetInt() != 0), nil
 	case reflect.Slice:
 		if t.Elem().Kind() == reflect.Uint8 {
-			if len(data.GetBytes()) == 0 {
-				strVal := data.GetString_()
-				if strVal != "" {
-					return reflect.ValueOf([]byte(strVal)), nil
-				}
+			if b := data.GetBytes(); len(b) > 0 {
+				return reflect.ValueOf(b), nil
 			}
-			return reflect.ValueOf(data.GetBytes()), nil
+			if s := data.GetString_(); s != "" {
+				return reflect.ValueOf([]byte(s)), nil
+			}
+			// Fall through to JSON handling below — host may deliver
+			// the payload as TypedData_Json (e.g. queue messages with
+			// JSON bodies). The bytes fallback at the end of the
+			// function will pick up GetJson() if populated.
 		}
 	case reflect.Int:
 		if data.GetInt() != 0 {
@@ -218,8 +221,11 @@ func decodeProto(data *pb.TypedData, t reflect.Type) (reflect.Value, error) {
 		}
 	}
 
-	// JSON fallback
-	if data.GetJson() != "" {
+	// JSON fallback. Skip when target is []byte — for byte slices we want
+	// to preserve the raw JSON payload (handled by the "Json handling
+	// (bytes support)" block below) rather than attempting to unmarshal a
+	// JSON document into a []byte (which would fail).
+	if data.GetJson() != "" && !(t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Uint8) {
 		v := reflect.New(t).Interface()
 		err := json.Unmarshal([]byte(data.GetJson()), v)
 		if err != nil {

--- a/worker/converter_test.go
+++ b/worker/converter_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"encoding/json"
 	"net/http"
 	"reflect"
 	"strings"
@@ -393,6 +394,43 @@ func TestConvertToTypeValue_TimerInfo_StringJSON(t *testing.T) {
 }
 
 // --- encodeHTTPResponse tests ---
+
+// TestConvertToTypeValue_AzFuncData_JSONBody is a regression test for the
+// case where a queue (or service bus) message has a JSON object/array as
+// its body. Without the azfuncdata-aware guard in convertToTypeValue, the
+// whole-struct JSON fast-path would silently succeed against the body's
+// JSON (matching no field tags) and return an entirely empty struct —
+// the per-field metadata + azfuncdata fallback would never run.
+func TestConvertToTypeValue_AzFuncData_JSONBody(t *testing.T) {
+	type queueMsg struct {
+		Body         json.RawMessage `json:"azfuncdata"`
+		Id           string          `json:"id"`
+		DequeueCount int64           `json:"dequeueCount"`
+	}
+
+	bodyJSON := `{"orderId":123,"customer":"acme"}`
+	data := &pb.TypedData{Data: &pb.TypedData_Json{Json: bodyJSON}}
+	metadata := map[string]*pb.TypedData{
+		"Id":           {Data: &pb.TypedData_String_{String_: "msg-xyz"}},
+		"DequeueCount": {Data: &pb.TypedData_Json{Json: `2`}},
+	}
+
+	v, err := convertToTypeValue(reflect.TypeOf(queueMsg{}), data, metadata)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result := v.Interface().(queueMsg)
+
+	if string(result.Body) != bodyJSON {
+		t.Errorf("expected Body=%q, got %q", bodyJSON, string(result.Body))
+	}
+	if result.Id != "msg-xyz" {
+		t.Errorf("expected Id=%q, got %q", "msg-xyz", result.Id)
+	}
+	if result.DequeueCount != 2 {
+		t.Errorf("expected DequeueCount=2, got %d", result.DequeueCount)
+	}
+}
 
 func TestEncodeHTTPResponse(t *testing.T) {
 	proxy := NewResponseWriterProxy()

--- a/worker/converter_test.go
+++ b/worker/converter_test.go
@@ -432,6 +432,39 @@ func TestConvertToTypeValue_AzFuncData_JSONBody(t *testing.T) {
 	}
 }
 
+// TestConvertToTypeValue_ServiceBusMessage_JSONBody exercises the same
+// azfuncdata fast-path skip on a real bindings.ServiceBusMessage. It is
+// the sibling of the queueMsg case above and guards the Service Bus half
+// of the converter change against silent regressions.
+func TestConvertToTypeValue_ServiceBusMessage_JSONBody(t *testing.T) {
+	bodyJSON := `{"orderId":456,"customer":"contoso"}`
+	data := &pb.TypedData{Data: &pb.TypedData_Json{Json: bodyJSON}}
+	metadata := map[string]*pb.TypedData{
+		"messageId":     {Data: &pb.TypedData_String_{String_: "sb-msg-1"}},
+		"deliveryCount": {Data: &pb.TypedData_Json{Json: `3`}},
+		"contentType":   {Data: &pb.TypedData_String_{String_: "application/json"}},
+	}
+
+	v, err := convertToTypeValue(reflect.TypeOf(bindings.ServiceBusMessage{}), data, metadata)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result := v.Interface().(bindings.ServiceBusMessage)
+
+	if string(result.Body) != bodyJSON {
+		t.Errorf("expected Body=%q, got %q", bodyJSON, string(result.Body))
+	}
+	if result.MessageId != "sb-msg-1" {
+		t.Errorf("expected MessageId=%q, got %q", "sb-msg-1", result.MessageId)
+	}
+	if result.DeliveryCount != 3 {
+		t.Errorf("expected DeliveryCount=3, got %d", result.DeliveryCount)
+	}
+	if result.ContentType != "application/json" {
+		t.Errorf("expected ContentType=%q, got %q", "application/json", result.ContentType)
+	}
+}
+
 func TestEncodeHTTPResponse(t *testing.T) {
 	proxy := NewResponseWriterProxy()
 	proxy.Header().Set("Content-Type", "text/plain")

--- a/worker/converter_test.go
+++ b/worker/converter_test.go
@@ -124,6 +124,129 @@ func TestDecodeProto_BoolFromString(t *testing.T) {
 	}
 }
 
+// TestDecodeProto_Fallbacks is a table-driven test covering decodeProto's
+// fallback paths. The function tries the "natural" TypedData variant for the
+// target Go type first (String_ for string, Int for int64, etc.) and falls
+// through to JSON/bytes handling when that variant is empty. Different host
+// extensions populate different variants — for example the Storage Queue
+// extension sends DequeueCount as TypedData_Json and time fields as
+// JSON-quoted strings — so these fallbacks must be reliable.
+func TestDecodeProto_Fallbacks(t *testing.T) {
+	type payload struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+
+	tests := []struct {
+		name      string
+		data      *pb.TypedData
+		target    interface{}
+		expected  interface{}
+		expectErr bool
+	}{
+		// --- string target ---
+		{
+			name:     "string from TypedData_String_ (direct, preferred)",
+			data:     &pb.TypedData{Data: &pb.TypedData_String_{String_: "direct"}},
+			target:   "",
+			expected: "direct",
+		},
+		{
+			name:     "string from TypedData_Json (queue ExpirationTime scenario)",
+			data:     &pb.TypedData{Data: &pb.TypedData_Json{Json: `"2026-06-29T19:04:34+00:00"`}},
+			target:   "",
+			expected: "2026-06-29T19:04:34+00:00",
+		},
+		{
+			name:     "string from TypedData_Bytes",
+			data:     &pb.TypedData{Data: &pb.TypedData_Bytes{Bytes: []byte("from bytes")}},
+			target:   "",
+			expected: "from bytes",
+		},
+		{
+			name:     "empty TypedData_String_ yields zero value",
+			data:     &pb.TypedData{Data: &pb.TypedData_String_{String_: ""}},
+			target:   "",
+			expected: "",
+		},
+
+		// --- int target ---
+		{
+			name:     "int64 from TypedData_Json (queue DequeueCount scenario)",
+			data:     &pb.TypedData{Data: &pb.TypedData_Json{Json: `1`}},
+			target:   int64(0),
+			expected: int64(1),
+		},
+		{
+			name:     "int from TypedData_Json",
+			data:     &pb.TypedData{Data: &pb.TypedData_Json{Json: `7`}},
+			target:   int(0),
+			expected: int(7),
+		},
+
+		// --- float target ---
+		{
+			name:     "float64 from TypedData_Json",
+			data:     &pb.TypedData{Data: &pb.TypedData_Json{Json: `2.718`}},
+			target:   float64(0),
+			expected: float64(2.718),
+		},
+
+		// --- struct target ---
+		{
+			name:     "struct from TypedData_String_ containing JSON",
+			data:     &pb.TypedData{Data: &pb.TypedData_String_{String_: `{"name":"Alice","age":30}`}},
+			target:   payload{},
+			expected: payload{Name: "Alice", Age: 30},
+		},
+		{
+			name:      "struct from malformed TypedData_Json returns error",
+			data:      &pb.TypedData{Data: &pb.TypedData_Json{Json: `{invalid`}},
+			target:    payload{},
+			expectErr: true,
+		},
+
+		// --- []byte / json.RawMessage target (e.g. QueueMessage.Body) ---
+		{
+			name:     "[]byte from TypedData_Bytes",
+			data:     &pb.TypedData{Data: &pb.TypedData_Bytes{Bytes: []byte("raw bytes")}},
+			target:   []byte(nil),
+			expected: []byte("raw bytes"),
+		},
+		{
+			name:     "[]byte from TypedData_String_",
+			data:     &pb.TypedData{Data: &pb.TypedData_String_{String_: "string body"}},
+			target:   []byte(nil),
+			expected: []byte("string body"),
+		},
+		{
+			name:     "[]byte from TypedData_Json (queue body as JSON variant)",
+			data:     &pb.TypedData{Data: &pb.TypedData_Json{Json: `{"k":"v"}`}},
+			target:   []byte(nil),
+			expected: []byte(`{"k":"v"}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := decodeProto(tc.data, reflect.TypeOf(tc.target))
+			if tc.expectErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got := v.Interface()
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("expected %v (%T), got %v (%T)", tc.expected, tc.expected, got, got)
+			}
+		})
+	}
+}
+
 // --- FromProto tests ---
 
 func TestFromProto_StringInput(t *testing.T) {


### PR DESCRIPTION
**Summary**

 Adds a  queueTrigger  binding so functions can be triggered by Azure Storage Queue messages, plus a converter fix ensuring queue/Service Bus messages with JSON bodies  populate correctly.

 **Changes**

 • Queue trigger SDK: New  QueueStorageTrigger ,  QueueBinding , and  QueueMessage  types;  app.Queue(...)  registration;  QueueHandler  handler type.
 • Options:  WithQueueName  and  WithConnection  now also apply to Storage Queue bindings.
 • Converter fix: Structs with an  azfuncdata -tagged field now skip the whole-struct JSON fast-path, so a JSON-object queue body is routed to  Body  (with metadata    fields populated separately) instead of silently producing a zero-valued message.
 • Decode robustness:  decodeProto  handles host extensions delivering values via different  TypedData  variants (e.g. queue  DequeueCount  as JSON number, time fields as    JSON strings, JSON bodies into  []byte / json.RawMessage ).
 • Telemetry: otel middleware classifies  queueTrigger  as  pubsub  and  sqlTrigger  as  datasource .

 **Tests**

 • New converter unit tests, queue binding tests, app registration tests, and a queue storage integration test.
 • Sample app under  samples/queueTrigger/ .