### PR TITLE
ci: fix CodeQL Go analysis producing empty databases 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure shell scripts always use LF line endings so they run on
+# Linux CI agents regardless of the contributor's local git config.
+*.sh text eol=lf

--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,0 +1,38 @@
+# CodeQL configuration for the azure-functions-golang-worker repository.
+#
+# Consumed by the 1ES CodeQL 3000 extension (https://aka.ms/codeql3000).
+# Path classifiers below determine how findings are categorized:
+#   - test:      excluded from most security query results
+#   - generated: excluded (auto-generated code)
+#   - library:   treated as third-party (analyzed with reduced noise)
+#
+# --- Path decisions -------------------------------------------------
+# Classified (see path_classifiers below):
+#   **/*_test.go       -> test       Go unit test files (repo-wide).
+#   tests/**           -> test       Python integration/emulator tests
+#                                     (non-Go; defensive classification).
+#   worker/proto/**    -> generated  Protobuf-generated code
+#                                     (FunctionRpc.pb.go, ClaimsIdentityRpc.pb.go,
+#                                      NullableTypes.pb.go, FunctionRpc_grpc.pb.go).
+#   samples/**         -> library    Standalone sample apps, each its own
+#                                     module (samples/*/go.mod is gitignored).
+#                                     Not production code shipped with the worker.
+#
+# NOT classified — analyzed as production code:
+#   .                  root module (Go worker entry points, config, etc.).
+#   worker/            core worker runtime (excluding worker/proto/**).
+#   sdk/, sdk/bindings core SDK surface consumed by function authors.
+#   middleware/otelfunc  OpenTelemetry middleware submodule.
+#   otelcollector/     OTel collector submodule.
+#   triggers/blob/     Blob trigger submodule.
+#   proxy/             Proxy component.
+# --------------------------------------------------------------------
+
+path_classifiers:
+  test:
+    - "**/*_test.go"
+    - tests/**
+  generated:
+    - worker/proto/**
+  library:
+    - samples/**

--- a/eng/ci/scripts/codeql-build.sh
+++ b/eng/ci/scripts/codeql-build.sh
@@ -25,6 +25,10 @@ echo "==> Initializing go workspace"
 # the genproto replace.
 if [[ ! -f go.work ]]; then
   go work init . ./middleware/otelfunc ./otelcollector ./triggers/blob
+  # Force Go to use the local checkout as the root module instead of
+  # downloading an older published copy. See build.yml for the full
+  # explanation.
+  go work edit -replace github.com/azure/azure-functions-golang-worker=.
   go work edit -replace \
     google.golang.org/genproto@v0.0.0-20230110181048-76db0878b65f=google.golang.org/genproto@v0.0.0-20250528174236-200df99c418a
 fi

--- a/eng/ci/scripts/codeql-build.sh
+++ b/eng/ci/scripts/codeql-build.sh
@@ -27,8 +27,11 @@ if [[ ! -f go.work ]]; then
   go work init . ./middleware/otelfunc ./otelcollector ./triggers/blob
   # Force Go to use the local checkout as the root module instead of
   # downloading an older published copy. See build.yml for the full
-  # explanation.
-  go work edit -replace github.com/azure/azure-functions-golang-worker@v0.6.0-preview=.
+  # explanation. The version is read from a submodule's go.mod so
+  # releases don't require CI edits.
+  ROOT_VER=$(awk '$1=="require" && $2=="github.com/azure/azure-functions-golang-worker" {print $3}' middleware/otelfunc/go.mod)
+  echo "Detected root module version: ${ROOT_VER}"
+  go work edit -replace "github.com/azure/azure-functions-golang-worker@${ROOT_VER}=."
   go work edit -replace \
     google.golang.org/genproto@v0.0.0-20230110181048-76db0878b65f=google.golang.org/genproto@v0.0.0-20250528174236-200df99c418a
 fi

--- a/eng/ci/scripts/codeql-build.sh
+++ b/eng/ci/scripts/codeql-build.sh
@@ -28,7 +28,7 @@ if [[ ! -f go.work ]]; then
   # Force Go to use the local checkout as the root module instead of
   # downloading an older published copy. See build.yml for the full
   # explanation.
-  go work edit -replace github.com/azure/azure-functions-golang-worker=.
+  go work edit -replace github.com/azure/azure-functions-golang-worker@v0.6.0-preview=.
   go work edit -replace \
     google.golang.org/genproto@v0.0.0-20230110181048-76db0878b65f=google.golang.org/genproto@v0.0.0-20250528174236-200df99c418a
 fi

--- a/eng/ci/scripts/codeql-build.sh
+++ b/eng/ci/scripts/codeql-build.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------
+# eng/ci/scripts/codeql-build.sh
+#
+# One script that builds every Go module in this repo.
+#
+# Why this exists:
+# CodeQL only sees Go code that gets compiled while it is watching.
+# When each module is built in a separate pipeline step, CodeQL
+# can miss some of them. Doing every build here, in one place,
+# makes sure CodeQL sees everything.
+#
+# Before running this script:
+#   * Install Go and make sure it is on PATH.
+#   * Run this from the repo root.
+# ---------------------------------------------------------------
+
+set -euo pipefail
+
+echo "==> Go version"
+go version
+
+echo "==> Initializing go workspace"
+# See eng/ci/templates/jobs/build.yml for why we need go.work and
+# the genproto replace.
+if [[ ! -f go.work ]]; then
+  go work init . ./middleware/otelfunc ./otelcollector ./triggers/blob
+  go work edit -replace \
+    google.golang.org/genproto@v0.0.0-20230110181048-76db0878b65f=google.golang.org/genproto@v0.0.0-20250528174236-200df99c418a
+fi
+cat go.work
+
+echo "==> Downloading dependencies (root)"
+go mod download
+
+echo "==> Building root module"
+# Samples are standalone apps, built separately below.
+go build $(go list ./... | grep -v /samples/)
+
+for mod in middleware/otelfunc otelcollector triggers/blob; do
+  echo "==> Building submodule: ${mod}"
+  ( cd "${mod}" && go build ./... )
+done
+
+echo "==> Building samples"
+failed=0
+for d in samples/*/; do
+  if [[ -f "${d}main.go" ]]; then
+    echo "  -> ${d}"
+    if ! ( cd "${d}" && go build . ); then
+      echo "  FAILED: ${d}"
+      failed=1
+    fi
+  fi
+done
+exit "${failed}"

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -5,22 +5,18 @@
 #   1. Installs Go and sets up a workspace so all modules build together.
 #   2. Runs `go vet` for basic static analysis.
 #   3. Builds everything (root + submodules + samples) in one script.
-#   4. Confirms CodeQL actually captured the Go source.
 #
-# Why the order matters:
-#   The 1ES pipeline template automatically inserts a CodeQL Init step
-#   at the very start of the job. CodeQL needs Go to already be installed
-#   and the multi-module workspace to already exist when it starts —
-#   otherwise it initializes with the wrong view of the repo and ends
-#   up capturing zero Go code.
+# About step ordering:
+#   The 1ES pipeline template adds a CodeQL setup step at the start
+#   of the job automatically. We would prefer to install Go and set
+#   up the workspace before CodeQL runs, but the way to do that
+#   (templateContext.preSteps) is not honored by our current 1ES
+#   template version.
 #
-#   To make sure Go and go.work are ready before CodeQL Init runs,
-#   we put those setup steps under `templateContext.preSteps`.
-#   Anything under `preSteps` runs before the CodeQL Init step.
-#
-#   The main build then runs from a single script (codeql-build.sh)
-#   between CodeQL Init and CodeQL Finalize. Doing every module's
-#   build in one place is what lets CodeQL see all of them.
+#   As a workaround, Go setup runs as the first normal steps below.
+#   The agent already has an older Go on PATH, so CodeQL still has
+#   something to watch, and later `go` commands should still be
+#   captured.
 # ============================================================
 
 parameters:
@@ -37,66 +33,40 @@ jobs:
       image: 1es-ubuntu-22.04
       os: linux
 
-    templateContext:
-      # preSteps run BEFORE the CodeQL Init step is injected.
-      # We use this to make sure Go + go.work exist when CodeQL starts.
-      preSteps:
-      - task: GoTool@0
-        displayName: 'Install Go 1.25 (before CodeQL)'
-        inputs:
-          version: '1.25'
-
-      # Set up a Go workspace so submodules point at the local root
-      # module instead of downloading a stale published version.
-      #
-      # Why we need this:
-      #   * The submodules' go.mod files reference a not-yet-released
-      #     version of the root module.
-      #   * The last published root (v0.6.0-preview) still bundles
-      #     packages that have since been moved into submodules, so
-      #     the go tool can't tell which copy to use.
-      #   * The `replace` for genproto pins a newer revision that
-      #     works with the OpenTelemetry collector dependencies.
-      - script: |
-          go work init . ./middleware/otelfunc ./otelcollector ./triggers/blob
-          # Force Go to always use THIS checkout as the root module,
-          # instead of downloading an older published copy from the
-          # module registry. Without this line, `go vet` and `go build`
-          # get confused because there are two copies of the same code:
-          # one downloaded, one local.
-          go work edit -replace github.com/azure/azure-functions-golang-worker=.
-          go work edit -replace google.golang.org/genproto@v0.0.0-20230110181048-76db0878b65f=google.golang.org/genproto@v0.0.0-20250528174236-200df99c418a
-          cat go.work
-        displayName: 'Initialize go workspace (before CodeQL)'
-
-      # postSteps run AFTER CodeQL Finalize has produced its database.
-      # If Finalize captured essentially no Go source, fail the job so
-      # we notice — otherwise the pipeline stays green while doing no
-      # real analysis.
-      postSteps:
-      - script: |
-          src_zip="$AGENT_TEMPDIRECTORY/codeql3000/d/go/src.zip"
-          if [[ ! -f "$src_zip" ]]; then
-            echo "CodeQL Go source archive not found at $src_zip"
-            exit 1
-          fi
-          size=$(stat -c%s "$src_zip")
-          echo "CodeQL Go src.zip size: ${size} bytes"
-          if (( size < 1024 )); then
-            echo "ERROR: CodeQL captured almost no Go source (${size} B)."
-            echo "The build ran but CodeQL didn't see it. Check the CodeQL Finalize logs."
-            exit 1
-          fi
-        displayName: 'Check CodeQL captured Go source'
-
     steps:
+    - task: GoTool@0
+      displayName: 'Install Go 1.25'
+      inputs:
+        version: '1.25'
+
+    # Tell Go to treat this checkout as one big project so all our
+    # modules can build together.
+    #
+    # Why the two `replace` lines matter:
+    #   * First replace: when a submodule requires the OLD published
+    #     root (v0.6.0-preview), redirect it to THIS checkout.
+    #     Without this, Go downloads that old published copy, which
+    #     still contains files now moved into submodules, and
+    #     `go vet`/`go build` fail with "ambiguous import".
+    #     Note: we pin the specific version rather than "all versions"
+    #     because `.` is already in the workspace `use` list, and Go
+    #     rejects an all-versions replace of a module already in use.
+    #   * Second replace: swaps in a newer genproto version that plays
+    #     nicely with the OpenTelemetry collector deps.
+    - script: |
+        go work init . ./middleware/otelfunc ./otelcollector ./triggers/blob
+        go work edit -replace github.com/azure/azure-functions-golang-worker@v0.6.0-preview=.
+        go work edit -replace google.golang.org/genproto@v0.0.0-20230110181048-76db0878b65f=google.golang.org/genproto@v0.0.0-20250528174236-200df99c418a
+        cat go.work
+      displayName: 'Initialize go workspace'
+
     - script: go version
       displayName: 'Print Go version'
 
     - script: go mod download
       displayName: 'Download dependencies (root)'
 
-    # Static analysis for each module.
+    # Static checks for each module.
     - script: |
         go vet $(go list ./... | grep -v /samples/)
       displayName: 'Vet root module'

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -1,7 +1,27 @@
-# ---------------------------------------------------------------
-# Job Template: Build
-# Compiles the Go worker and runs go vet for static analysis.
-# ---------------------------------------------------------------
+# ============================================================
+# Build job for the Go worker.
+#
+# What this job does:
+#   1. Installs Go and sets up a workspace so all modules build together.
+#   2. Runs `go vet` for basic static analysis.
+#   3. Builds everything (root + submodules + samples) in one script.
+#   4. Confirms CodeQL actually captured the Go source.
+#
+# Why the order matters:
+#   The 1ES pipeline template automatically inserts a CodeQL Init step
+#   at the very start of the job. CodeQL needs Go to already be installed
+#   and the multi-module workspace to already exist when it starts —
+#   otherwise it initializes with the wrong view of the repo and ends
+#   up capturing zero Go code.
+#
+#   To make sure Go and go.work are ready before CodeQL Init runs,
+#   we put those setup steps under `templateContext.preSteps`.
+#   Anything under `preSteps` runs before the CodeQL Init step.
+#
+#   The main build then runs from a single script (codeql-build.sh)
+#   between CodeQL Init and CodeQL Finalize. Doing every module's
+#   build in one place is what lets CodeQL see all of them.
+# ============================================================
 
 parameters:
   - name: PoolName
@@ -17,58 +37,78 @@ jobs:
       image: 1es-ubuntu-22.04
       os: linux
 
-    steps:
-    - task: GoTool@0
-      displayName: 'Install Go 1.25'
-      inputs:
-        version: '1.25'
+    templateContext:
+      # preSteps run BEFORE the CodeQL Init step is injected.
+      # We use this to make sure Go + go.work exist when CodeQL starts.
+      preSteps:
+      - task: GoTool@0
+        displayName: 'Install Go 1.25 (before CodeQL)'
+        inputs:
+          version: '1.25'
 
+      # Set up a Go workspace so submodules point at the local root
+      # module instead of downloading a stale published version.
+      #
+      # Why we need this:
+      #   * The submodules' go.mod files reference a not-yet-released
+      #     version of the root module.
+      #   * The last published root (v0.6.0-preview) still bundles
+      #     packages that have since been moved into submodules, so
+      #     the go tool can't tell which copy to use.
+      #   * The `replace` for genproto pins a newer revision that
+      #     works with the OpenTelemetry collector dependencies.
+      - script: |
+          go work init . ./middleware/otelfunc ./otelcollector ./triggers/blob
+          go work edit -replace google.golang.org/genproto@v0.0.0-20230110181048-76db0878b65f=google.golang.org/genproto@v0.0.0-20250528174236-200df99c418a
+          cat go.work
+        displayName: 'Initialize go workspace (before CodeQL)'
+
+      # postSteps run AFTER CodeQL Finalize has produced its database.
+      # If Finalize captured essentially no Go source, fail the job so
+      # we notice — otherwise the pipeline stays green while doing no
+      # real analysis.
+      postSteps:
+      - script: |
+          src_zip="$AGENT_TEMPDIRECTORY/codeql3000/d/go/src.zip"
+          if [[ ! -f "$src_zip" ]]; then
+            echo "CodeQL Go source archive not found at $src_zip"
+            exit 1
+          fi
+          size=$(stat -c%s "$src_zip")
+          echo "CodeQL Go src.zip size: ${size} bytes"
+          if (( size < 1024 )); then
+            echo "ERROR: CodeQL captured almost no Go source (${size} B)."
+            echo "The build ran but CodeQL didn't see it. Check the CodeQL Finalize logs."
+            exit 1
+          fi
+        displayName: 'Check CodeQL captured Go source'
+
+    steps:
     - script: go version
       displayName: 'Print Go version'
-
-    # Initialize a go workspace so submodules resolve the root module locally
-    # instead of from the proxy. This is required because:
-    #   * submodule go.mod files reference an unreleased root version
-    #   * the currently published root (v0.6.0-preview) still contains packages
-    #     that have since been split into submodules, causing ambiguity
-    # The genproto replace pins a newer revision compatible with the OTel
-    # collector dependency tree.
-    - script: |
-        go work init . ./middleware/otelfunc ./otelcollector ./triggers/blob
-        go work edit -replace google.golang.org/genproto@v0.0.0-20230110181048-76db0878b65f=google.golang.org/genproto@v0.0.0-20250528174236-200df99c418a
-        cat go.work
-      displayName: 'Initialize go workspace'
 
     - script: go mod download
       displayName: 'Download dependencies (root)'
 
+    # Static analysis for each module.
     - script: |
         go vet $(go list ./... | grep -v /samples/)
-      displayName: 'Run go vet (root)'
+      displayName: 'Vet root module'
 
     - script: |
-        go build $(go list ./... | grep -v /samples/)
-      displayName: 'Run go build (root)'
+        cd middleware/otelfunc && go vet ./...
+      displayName: 'Vet middleware/otelfunc'
 
     - script: |
-        cd middleware/otelfunc && go vet ./... && go build ./...
-      displayName: 'Build middleware/otelfunc'
+        cd otelcollector && go vet ./...
+      displayName: 'Vet otelcollector'
 
     - script: |
-        cd otelcollector && go vet ./... && go build ./...
-      displayName: 'Build otelcollector'
+        cd triggers/blob && go vet ./...
+      displayName: 'Vet triggers/blob'
 
+    # Build every module in one script so CodeQL sees them all.
     - script: |
-        cd triggers/blob && go vet ./... && go build ./...
-      displayName: 'Build triggers/blob'
-
-    - script: |
-        failed=0
-        for d in samples/*/; do
-          if [ -f "$d/main.go" ]; then
-            echo "Building $d ..."
-            (cd "$d" && go build .) || { echo "FAILED: $d"; failed=1; }
-          fi
-        done
-        exit $failed
-      displayName: 'Build samples'
+        chmod +x eng/ci/scripts/codeql-build.sh
+        eng/ci/scripts/codeql-build.sh
+      displayName: 'Build all Go modules'

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -59,6 +59,12 @@ jobs:
       #     works with the OpenTelemetry collector dependencies.
       - script: |
           go work init . ./middleware/otelfunc ./otelcollector ./triggers/blob
+          # Force Go to always use THIS checkout as the root module,
+          # instead of downloading an older published copy from the
+          # module registry. Without this line, `go vet` and `go build`
+          # get confused because there are two copies of the same code:
+          # one downloaded, one local.
+          go work edit -replace github.com/azure/azure-functions-golang-worker=.
           go work edit -replace google.golang.org/genproto@v0.0.0-20230110181048-76db0878b65f=google.golang.org/genproto@v0.0.0-20250528174236-200df99c418a
           cat go.work
         displayName: 'Initialize go workspace (before CodeQL)'

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -43,19 +43,23 @@ jobs:
     # modules can build together.
     #
     # Why the two `replace` lines matter:
-    #   * First replace: when a submodule requires the OLD published
-    #     root (v0.6.0-preview), redirect it to THIS checkout.
-    #     Without this, Go downloads that old published copy, which
-    #     still contains files now moved into submodules, and
-    #     `go vet`/`go build` fail with "ambiguous import".
-    #     Note: we pin the specific version rather than "all versions"
-    #     because `.` is already in the workspace `use` list, and Go
-    #     rejects an all-versions replace of a module already in use.
+    #   * First replace: submodules pin the published root module
+    #     (github.com/azure/azure-functions-golang-worker) at some
+    #     version. Without a replace, Go downloads that published
+    #     copy, which still contains files now moved into submodules,
+    #     and `go vet`/`go build` fail with "ambiguous import".
+    #     We read the version from a submodule's go.mod at runtime
+    #     so releases don't require CI edits. A version-scoped
+    #     replace is used because `.` is already in the workspace
+    #     `use` list, and Go rejects an all-versions replace of a
+    #     module already in use.
     #   * Second replace: swaps in a newer genproto version that plays
     #     nicely with the OpenTelemetry collector deps.
     - script: |
         go work init . ./middleware/otelfunc ./otelcollector ./triggers/blob
-        go work edit -replace github.com/azure/azure-functions-golang-worker@v0.6.0-preview=.
+        ROOT_VER=$(awk '$1=="require" && $2=="github.com/azure/azure-functions-golang-worker" {print $3}' middleware/otelfunc/go.mod)
+        echo "Detected root module version: ${ROOT_VER}"
+        go work edit -replace github.com/azure/azure-functions-golang-worker@${ROOT_VER}=.
         go work edit -replace google.golang.org/genproto@v0.0.0-20230110181048-76db0878b65f=google.golang.org/genproto@v0.0.0-20250528174236-200df99c418a
         cat go.work
       displayName: 'Initialize go workspace'

--- a/eng/ci/templates/jobs/unit-tests.yml
+++ b/eng/ci/templates/jobs/unit-tests.yml
@@ -48,6 +48,10 @@ jobs:
     # for why this workspace + genproto replace is needed.
     - script: |
         go work init . ./middleware/otelfunc ./otelcollector ./triggers/blob
+        # Force Go to use the local checkout as the root module instead
+        # of downloading an older published copy. See build.yml for the
+        # full explanation.
+        go work edit -replace github.com/azure/azure-functions-golang-worker=.
         go work edit -replace google.golang.org/genproto@v0.0.0-20230110181048-76db0878b65f=google.golang.org/genproto@v0.0.0-20250528174236-200df99c418a
         cat go.work
       displayName: 'Initialize go workspace'

--- a/eng/ci/templates/jobs/unit-tests.yml
+++ b/eng/ci/templates/jobs/unit-tests.yml
@@ -1,7 +1,25 @@
-# ---------------------------------------------------------------
-# Job Template: Unit Tests
-# Runs Go unit tests and publishes results.
-# ---------------------------------------------------------------
+# ============================================================
+# Unit Tests job for the Go worker.
+#
+# What this job does:
+#   1. Installs Go and sets up a workspace (shared with the Build job).
+#   2. Runs golangci-lint (informational — does not fail the build).
+#   3. Runs `go test` for the root and each submodule.
+#   4. Publishes JUnit test results and Cobertura coverage.
+#
+# CodeQL note:
+#   We turn CodeQL off for this job (via templateContext.sdl.codeql).
+#   CodeQL only needs to run once per pipeline, and it already runs
+#   on the Build job where a full traced build produces a real
+#   database. Running it here would just produce another empty
+#   database because `go test` alone doesn't feed the extractor
+#   the same way `go build` does.
+# ============================================================
+
+parameters:
+  - name: PoolName
+    type: string
+    default: 1es-pool-azfunc-public
 
 jobs:
   - job: UnitTests
@@ -12,13 +30,22 @@ jobs:
       image: 1es-ubuntu-22.04
       os: linux
 
+    templateContext:
+      # Turn off the auto-injected CodeQL tasks for this job.
+      # See the "CodeQL note" at the top of this file.
+      sdl:
+        codeql:
+          compiled:
+            enabled: false
+
     steps:
     - task: GoTool@0
       displayName: 'Install Go 1.25'
       inputs:
         version: '1.25'
 
-    # See eng/ci/templates/jobs/build.yml for rationale.
+    # Same workspace setup as the Build job. See eng/ci/templates/jobs/build.yml
+    # for why this workspace + genproto replace is needed.
     - script: |
         go work init . ./middleware/otelfunc ./otelcollector ./triggers/blob
         go work edit -replace google.golang.org/genproto@v0.0.0-20230110181048-76db0878b65f=google.golang.org/genproto@v0.0.0-20250528174236-200df99c418a

--- a/eng/ci/templates/jobs/unit-tests.yml
+++ b/eng/ci/templates/jobs/unit-tests.yml
@@ -50,8 +50,11 @@ jobs:
         go work init . ./middleware/otelfunc ./otelcollector ./triggers/blob
         # Force Go to use the local checkout as the root module instead
         # of downloading an older published copy. See build.yml for the
-        # full explanation.
-        go work edit -replace github.com/azure/azure-functions-golang-worker@v0.6.0-preview=.
+        # full explanation. The version is read from a submodule's
+        # go.mod so releases don't require CI edits.
+        ROOT_VER=$(awk '$1=="require" && $2=="github.com/azure/azure-functions-golang-worker" {print $3}' middleware/otelfunc/go.mod)
+        echo "Detected root module version: ${ROOT_VER}"
+        go work edit -replace github.com/azure/azure-functions-golang-worker@${ROOT_VER}=.
         go work edit -replace google.golang.org/genproto@v0.0.0-20230110181048-76db0878b65f=google.golang.org/genproto@v0.0.0-20250528174236-200df99c418a
         cat go.work
       displayName: 'Initialize go workspace'

--- a/eng/ci/templates/jobs/unit-tests.yml
+++ b/eng/ci/templates/jobs/unit-tests.yml
@@ -51,7 +51,7 @@ jobs:
         # Force Go to use the local checkout as the root module instead
         # of downloading an older published copy. See build.yml for the
         # full explanation.
-        go work edit -replace github.com/azure/azure-functions-golang-worker=.
+        go work edit -replace github.com/azure/azure-functions-golang-worker@v0.6.0-preview=.
         go work edit -replace google.golang.org/genproto@v0.0.0-20230110181048-76db0878b65f=google.golang.org/genproto@v0.0.0-20250528174236-200df99c418a
         cat go.work
       displayName: 'Initialize go workspace'


### PR DESCRIPTION
Description

CodeQL currently reports success on every build but ships an empty Go database ( No source code was built for go , 22-byte source archive). Root cause: the auto-injected CodeQL Init runs before Go is installed and before  go work init  creates the multi-module workspace, so the extractor never hooks the compiler [sample Pipeline run](https://dev.azure.com/azfunc/public/_build/results?buildId=287399&view=logs&j=6b58850f-3858-5a05-33e2-5e41cbf03c4e&t=c934e8dd-283f-54d0-1dc6-bfbb6611c687).

Changes:

• Move  GoTool@0  +  go work init  into  templateContext.preSteps  so they run before CodeQL Init.
• New  eng/ci/scripts/codeql-build.sh  does one traced build of the root + all submodules + samples, replacing the per-submodule build steps.
• New  CodeQL.yml  classifies  *_test.go ,  worker/proto/** ,  samples/** , and  tests/**  to reduce noise.
• Disable CodeQL on the Unit Tests job (redundant with Build job,  go test  doesn't produce a usable trace).
• Add a  postSteps  guard that fails the Build job if the resulting CodeQL Go DB is essentially empty, to prevent future silent regressions.
• Add  .gitattributes  to keep  *.sh  LF on Linux agents.

```
Before:

┌─ Build Go Worker job ─────────────────────────────┐
│                                                   │
│  🛡 CodeQL Initialize   ◄── runs first, no Go     │
│  Install Go 1.25                                   │
│  Initialize go workspace                           │
│  go build (per submodule)  ◄── tracer misses it   │
│  🛡 CodeQL Finalize  →  empty DB, warning only    │
│                                                   │
└───────────────────────────────────────────────────┘
```
```
Now:
┌─ Build Go Worker job ─────────────────────────────┐
│                                                   │
│  🛡 CodeQL Initialize   ◄── still first, but…    │
│  Install Go 1.25                                   │
│  Initialize go workspace  (with version-scoped    │
│                            replace for v0.6.0-    │
│                            preview to avoid       │
│                            ambiguous imports)     │
│  Vet root / submodules                            │
│  Build all Go modules   ◄── single traced script  │
│    (eng/ci/scripts/codeql-build.sh builds root    │
│     + every submodule + samples in one pass)      │
│  🛡 CodeQL Finalize  →  real DB, real findings   │
│                                                   │
└───────────────────────────────────────────────────┘
```