### PR TITLE
ci: publish CodeQL extractor logs for diagnostics

### DIFF
--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -92,3 +92,12 @@ jobs:
         chmod +x eng/ci/scripts/codeql-build.sh
         eng/ci/scripts/codeql-build.sh
       displayName: 'Build all Go modules'
+
+    # Diagnostic: publish CodeQL extractor logs so we can debug when
+    # the database ends up empty. Safe to remove once CodeQL is stable.
+    - task: PublishPipelineArtifact@1
+      condition: always()
+      displayName: 'Publish CodeQL logs (diagnostic)'
+      inputs:
+        targetPath: '/mnt/vss/_work/_temp/codeql3000/d/log'
+        artifactName: 'codeql-logs-$(System.JobAttempt)'


### PR DESCRIPTION
Description:

CodeQL runs on  main  are still producing an empty Go database ( No source code was built for go , 22-byte src.zip) even after the earlier fixes. The extractor logs would tell us the actual root cause, but they live in  /mnt/vss/_work/_temp/codeql3000/d/log/  on the agent and aren't published anywhere.

This adds a  PublishPipelineArtifact  step to the Build Go Worker job that uploads those logs after the build.  condition: always()  so we get them even on failure;  $(System.JobAttempt)  in the artifact name to avoid rerun collisions.