### PR TITLE
 ci: fix CodeQL 3000 by disabling cadence and using built-in log publishing

### DIFF
--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -27,6 +27,9 @@ parameters:
 jobs:
   - job: Build
     displayName: 'Build Go Worker'
+    # Give CodeQL 3000 Finalize enough time to zip + upload the
+    # database/log artifacts if Init or Finalize is slow to cancel.
+    cancelTimeoutInMinutes: 45
 
     pool:
       name: ${{ parameters.PoolName }}
@@ -34,25 +37,20 @@ jobs:
       os: linux
 
     variables:
+      # CodeQL 3000 tuning. See:
+      # https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines
+      #
       # Run CodeQL on every build. Default (72h) throttles most PR
       # builds into an early exit with no database.
       - name: Codeql.Cadence
         value: 0
-
-    templateContext:
-      # Diagnostic: publish CodeQL extractor logs so we can debug
-      # when the database ends up empty. Uploaded via 1ES PT outputs
-      # (raw PublishPipelineArtifact@1 is blocked). The staging step
-      # below copies the logs into a stable path first, since
-      # /mnt/vss/_work/_temp/ may be cleaned up before outputs run.
-      # Safe to remove once CodeQL is stable.
-      outputs:
-        - output: pipelineArtifact
-          displayName: 'Publish CodeQL logs (diagnostic)'
-          condition: always()
-          targetPath: '$(Build.ArtifactStagingDirectory)/codeql-logs'
-          artifactName: 'codeql-logs-$(System.JobAttempt)'
-          sbomEnabled: false
+      # Publish CodeQL CLI logs and the (partial) database as
+      # pipeline artifacts. Uses the built-in CodeQL 3000 Finalize
+      # publisher, so we don't have to scrape agent temp dirs.
+      - name: Codeql.PublishDatabaseLog
+        value: true
+      - name: Codeql.PublishDatabase
+        value: true
 
     steps:
     - task: GoTool@0
@@ -114,34 +112,3 @@ jobs:
         eng/ci/scripts/codeql-build.sh
       displayName: 'Build all Go modules'
 
-    # Stage CodeQL diagnostic logs into the artifact staging dir so
-    # the templateContext output above can publish them. Runs before
-    # Post-Job cleanup wipes $(Agent.TempDirectory). The CodeQL3000
-    # log dir has moved around across tool versions, so probe every
-    # plausible location and copy whatever we find. Safe to remove
-    # once CodeQL is stable.
-    - script: |
-        set -x
-        STAGE="$(Build.ArtifactStagingDirectory)/codeql-logs"
-        mkdir -p "${STAGE}"
-        echo "=== agent temp layout ==="
-        ls -la "$(Agent.TempDirectory)" || true
-        find "$(Agent.TempDirectory)" -maxdepth 4 -type d -name codeql3000 -print 2>/dev/null || true
-
-        found=0
-        while IFS= read -r logdir; do
-          [ -z "${logdir}" ] && continue
-          echo "Copying logs from ${logdir}"
-          dest="${STAGE}/$(echo "${logdir}" | tr '/' '_' | sed 's/^_//')"
-          mkdir -p "${dest}"
-          cp -r "${logdir}/." "${dest}/" || true
-          found=1
-        done < <(find "$(Agent.TempDirectory)" -type d -name log \
-                   -path '*/codeql3000/*' 2>/dev/null)
-
-        if [ "${found}" -eq 0 ]; then
-          echo "CodeQL log dir not found under $(Agent.TempDirectory)." \
-            > "${STAGE}/README.txt"
-        fi
-      displayName: 'Stage CodeQL logs (diagnostic)'
-      condition: always()

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -33,6 +33,12 @@ jobs:
       image: 1es-ubuntu-22.04
       os: linux
 
+    variables:
+      # Run CodeQL on every build. Default (72h) throttles most PR
+      # builds into an early exit with no database.
+      - name: Codeql.Cadence
+        value: 0
+
     templateContext:
       # Diagnostic: publish CodeQL extractor logs so we can debug
       # when the database ends up empty. Uploaded via 1ES PT outputs
@@ -110,21 +116,32 @@ jobs:
 
     # Stage CodeQL diagnostic logs into the artifact staging dir so
     # the templateContext output above can publish them. Runs before
-    # Post-Job cleanup wipes /mnt/vss/_work/_temp. Tolerant of the
-    # log dir not existing so we still get a (possibly empty) artifact.
+    # Post-Job cleanup wipes $(Agent.TempDirectory). The CodeQL3000
+    # log dir has moved around across tool versions, so probe every
+    # plausible location and copy whatever we find. Safe to remove
+    # once CodeQL is stable.
     - script: |
         set -x
-        mkdir -p "$(Build.ArtifactStagingDirectory)/codeql-logs"
+        STAGE="$(Build.ArtifactStagingDirectory)/codeql-logs"
+        mkdir -p "${STAGE}"
         echo "=== agent temp layout ==="
-        ls -la /mnt/vss/_work/_temp/ || true
-        ls -la /mnt/vss/_work/_temp/codeql3000/ || true
-        ls -la /mnt/vss/_work/_temp/codeql3000/d/ || true
-        if [ -d /mnt/vss/_work/_temp/codeql3000/d/log ]; then
-          cp -r /mnt/vss/_work/_temp/codeql3000/d/log/. \
-                "$(Build.ArtifactStagingDirectory)/codeql-logs/"
-        else
-          echo "CodeQL log dir not found." \
-            > "$(Build.ArtifactStagingDirectory)/codeql-logs/README.txt"
+        ls -la "$(Agent.TempDirectory)" || true
+        find "$(Agent.TempDirectory)" -maxdepth 4 -type d -name codeql3000 -print 2>/dev/null || true
+
+        found=0
+        while IFS= read -r logdir; do
+          [ -z "${logdir}" ] && continue
+          echo "Copying logs from ${logdir}"
+          dest="${STAGE}/$(echo "${logdir}" | tr '/' '_' | sed 's/^_//')"
+          mkdir -p "${dest}"
+          cp -r "${logdir}/." "${dest}/" || true
+          found=1
+        done < <(find "$(Agent.TempDirectory)" -type d -name log \
+                   -path '*/codeql3000/*' 2>/dev/null)
+
+        if [ "${found}" -eq 0 ]; then
+          echo "CodeQL log dir not found under $(Agent.TempDirectory)." \
+            > "${STAGE}/README.txt"
         fi
       displayName: 'Stage CodeQL logs (diagnostic)'
       condition: always()


### PR DESCRIPTION
Description
CodeQL Init exits early on most builds with  CodeQL Init task ended without creating database, exiting, producing no database and no logs. Per the 1ES CodeQL 3000 docs, this is the documented symptom of the default 72h cadence throttle.

Fix. In  eng/ci/templates/jobs/build.yml :

•  Codeql.Cadence: 0  — run every build.
•  Codeql.PublishDatabaseLog  +  Codeql.PublishDatabase  — let Finalize publish logs/DB as artifacts.
•  cancelTimeoutInMinutes: 45  — give Finalize time to zip and upload.
• Removed the custom log-scraping step and its  templateContext.outputs  block; superseded by the built-in publisher.

https://aka.ms/codeql3000