### PR TITLE
ci: source CodeQL start-tracing script so go build runs under tracer

### DIFF
--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -107,7 +107,17 @@ jobs:
       displayName: 'Vet triggers/blob'
 
     # Build every module in one script so CodeQL sees them all.
+    #
+    # Source the CodeQL tracing script first so `go build` runs
+    # under the tracer. Without this the database ends up empty.
     - script: |
+        TRACE_SCRIPT="$(Agent.TempDirectory)/codeql3000/d/temp/tracingEnvironment/start-tracing.sh"
+        if [ -f "${TRACE_SCRIPT}" ]; then
+          echo "Sourcing CodeQL tracing env from ${TRACE_SCRIPT}"
+          source "${TRACE_SCRIPT}"
+        else
+          echo "CodeQL tracing script not found at ${TRACE_SCRIPT}; continuing without it."
+        fi
         chmod +x eng/ci/scripts/codeql-build.sh
         eng/ci/scripts/codeql-build.sh
       displayName: 'Build all Go modules'


### PR DESCRIPTION
To initialize indirect tracing, some environment variables need to be set in the context the build will run in.
`source /mnt/vss/_work/_temp/codeql3000/d/temp/tracingEnvironment/start-tracing.sh`

Our script:  step launches a fresh bash without those env vars, so  go build  runs untraced.  build-tracer.log  confirms: only unrelated  git /cgo helper calls get wrapped; no real  go build / go list  interceptions.

In  eng/ci/templates/jobs/build.yml , source  start-tracing.sh  at the top of the "Build all Go modules" step before running  codeql-build.sh , guarded by an existence check.
