### PR TITLE
ci: run CodeQL Go in dedicated autobuild job and exclude samples

### DIFF
--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,32 +1,14 @@
 # CodeQL configuration for the azure-functions-golang-worker repository.
-#
 # Consumed by the 1ES CodeQL 3000 extension (https://aka.ms/codeql3000).
-# Path classifiers below determine how findings are categorized:
-#   - test:      excluded from most security query results
-#   - generated: excluded (auto-generated code)
-#   - library:   treated as third-party (analyzed with reduced noise)
 #
-# --- Path decisions -------------------------------------------------
-# Classified (see path_classifiers below):
-#   **/*_test.go       -> test       Go unit test files (repo-wide).
-#   tests/**           -> test       Python integration/emulator tests
-#                                     (non-Go; defensive classification).
-#   worker/proto/**    -> generated  Protobuf-generated code
-#                                     (FunctionRpc.pb.go, ClaimsIdentityRpc.pb.go,
-#                                      NullableTypes.pb.go, FunctionRpc_grpc.pb.go).
-#   samples/**         -> library    Standalone sample apps, each its own
-#                                     module (samples/*/go.mod is gitignored).
-#                                     Not production code shipped with the worker.
-#
-# NOT classified — analyzed as production code:
-#   .                  root module (Go worker entry points, config, etc.).
-#   worker/            core worker runtime (excluding worker/proto/**).
-#   sdk/, sdk/bindings core SDK surface consumed by function authors.
-#   middleware/otelfunc  OpenTelemetry middleware submodule.
-#   otelcollector/     OTel collector submodule.
-#   triggers/blob/     Blob trigger submodule.
-#   proxy/             Proxy component.
-# --------------------------------------------------------------------
+# Classifiers reduce noise from non-production code:
+#   test       -> Go unit tests (**/*_test.go) and the tests/ tree.
+#   generated  -> Protobuf output under worker/proto/.
+# Samples are fully excluded (see queries.exclude below): sample apps are
+# standalone modules whose go.mod files are gitignored, so nothing under
+# samples/ is built in CI. Everything else (root, worker, sdk, proxy,
+# middleware/otelfunc, otelcollector, triggers/blob) is analyzed as
+# production code.
 
 path_classifiers:
   test:
@@ -34,5 +16,8 @@ path_classifiers:
     - tests/**
   generated:
     - worker/proto/**
-  library:
-    - samples/**
+
+queries:
+  - exclude:
+      path:
+        - "samples"

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -69,3 +69,11 @@ extends:
           - template: /eng/ci/templates/jobs/unit-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc
+
+      - stage: CodeQL
+        displayName: 'CodeQL Scan'
+        dependsOn: []
+        jobs:
+          - template: /eng/ci/templates/jobs/codeql.yml@self
+            parameters:
+              PoolName: 1es-pool-azfunc

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -39,6 +39,17 @@ extends:
         compiled:
           enabled: true
         language: go
+        # On PR builds against main, additionally run CodeQL analysis
+        # locally in the pipeline so results (SARIF + database) are
+        # available for review before merge. Results appear as the
+        # `CodeAnalysisLogs` pipeline artifact and, if the SARIF SAST
+        # Scans Tab ADO extension is installed, in the pipeline run's
+        # "Scans" tab. Note: PR-mode analysis does NOT upload to CAP
+        # Central or clear S360 alerts — a default-branch run is still
+        # required for compliance.
+        ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}:
+          enabledOnNonDefaultBranches: true
+          analyzeInPipeline: true
 
     settings:
       skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
@@ -54,5 +65,13 @@ extends:
         dependsOn: []
         jobs:
           - template: /eng/ci/templates/jobs/unit-tests.yml@self
+            parameters:
+              PoolName: 1es-pool-azfunc-public
+
+      - stage: CodeQL
+        displayName: 'CodeQL Scan'
+        dependsOn: []
+        jobs:
+          - template: /eng/ci/templates/jobs/codeql.yml@self
             parameters:
               PoolName: 1es-pool-azfunc-public

--- a/eng/ci/scripts/build-all.sh
+++ b/eng/ci/scripts/build-all.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
 # ---------------------------------------------------------------
-# eng/ci/scripts/codeql-build.sh
+# eng/ci/scripts/build-all.sh
 #
-# One script that builds every Go module in this repo.
-#
-# Why this exists:
-# CodeQL only sees Go code that gets compiled while it is watching.
-# When each module is built in a separate pipeline step, CodeQL
-# can miss some of them. Doing every build here, in one place,
-# makes sure CodeQL sees everything.
+# Builds every Go module in this repo (root + submodules) in one
+# script, using a temporary go.work so submodules resolve local
+# code instead of the published root module.
 #
 # Before running this script:
 #   * Install Go and make sure it is on PATH.
@@ -41,23 +37,11 @@ echo "==> Downloading dependencies (root)"
 go mod download
 
 echo "==> Building root module"
-# Samples are standalone apps, built separately below.
+# Samples are standalone apps with their own (gitignored) go.mod
+# files; they are excluded from CI builds and from CodeQL analysis.
 go build $(go list ./... | grep -v /samples/)
 
 for mod in middleware/otelfunc otelcollector triggers/blob; do
   echo "==> Building submodule: ${mod}"
   ( cd "${mod}" && go build ./... )
 done
-
-echo "==> Building samples"
-failed=0
-for d in samples/*/; do
-  if [[ -f "${d}main.go" ]]; then
-    echo "  -> ${d}"
-    if ! ( cd "${d}" && go build . ); then
-      echo "  FAILED: ${d}"
-      failed=1
-    fi
-  fi
-done
-exit "${failed}"

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -4,19 +4,12 @@
 # What this job does:
 #   1. Installs Go and sets up a workspace so all modules build together.
 #   2. Runs `go vet` for basic static analysis.
-#   3. Builds everything (root + submodules + samples) in one script.
+#   3. Builds root + submodules in one script.
 #
-# About step ordering:
-#   The 1ES pipeline template adds a CodeQL setup step at the start
-#   of the job automatically. We would prefer to install Go and set
-#   up the workspace before CodeQL runs, but the way to do that
-#   (templateContext.preSteps) is not honored by our current 1ES
-#   template version.
-#
-#   As a workaround, Go setup runs as the first normal steps below.
-#   The agent already has an older Go on PATH, so CodeQL still has
-#   something to watch, and later `go` commands should still be
-#   captured.
+# CodeQL note:
+#   CodeQL runs in its own dedicated job (see codeql.yml) using
+#   autobuild mode. Auto-injected CodeQL tasks are disabled for
+#   this job via templateContext.sdl.codeql below.
 # ============================================================
 
 parameters:
@@ -27,30 +20,22 @@ parameters:
 jobs:
   - job: Build
     displayName: 'Build Go Worker'
-    # Give CodeQL 3000 Finalize enough time to zip + upload the
-    # database/log artifacts if Init or Finalize is slow to cancel.
-    cancelTimeoutInMinutes: 45
 
     pool:
       name: ${{ parameters.PoolName }}
       image: 1es-ubuntu-22.04
       os: linux
 
-    variables:
-      # CodeQL 3000 tuning. See:
-      # https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines
-      #
-      # Run CodeQL on every build. Default (72h) throttles most PR
-      # builds into an early exit with no database.
-      - name: Codeql.Cadence
-        value: 0
-      # Publish CodeQL CLI logs and the (partial) database as
-      # pipeline artifacts. Uses the built-in CodeQL 3000 Finalize
-      # publisher, so we don't have to scrape agent temp dirs.
-      - name: Codeql.PublishDatabaseLog
-        value: true
-      - name: Codeql.PublishDatabase
-        value: true
+    templateContext:
+      # CodeQL runs in its own dedicated job (codeql.yml) using
+      # autobuild mode, which sidesteps the Go 1.21+ static-binary
+      # tracing issue on Linux. Turn off the auto-injected CodeQL
+      # tasks here so this Build job doesn't produce a second
+      # (empty) database.
+      sdl:
+        codeql:
+          compiled:
+            enabled: false
 
     steps:
     - task: GoTool@0
@@ -106,19 +91,8 @@ jobs:
         cd triggers/blob && go vet ./...
       displayName: 'Vet triggers/blob'
 
-    # Build every module in one script so CodeQL sees them all.
-    #
-    # Source the CodeQL tracing script first so `go build` runs
-    # under the tracer. Without this the database ends up empty.
     - script: |
-        TRACE_SCRIPT="$(Agent.TempDirectory)/codeql3000/d/temp/tracingEnvironment/start-tracing.sh"
-        if [ -f "${TRACE_SCRIPT}" ]; then
-          echo "Sourcing CodeQL tracing env from ${TRACE_SCRIPT}"
-          source "${TRACE_SCRIPT}"
-        else
-          echo "CodeQL tracing script not found at ${TRACE_SCRIPT}; continuing without it."
-        fi
-        chmod +x eng/ci/scripts/codeql-build.sh
-        eng/ci/scripts/codeql-build.sh
+        chmod +x eng/ci/scripts/build-all.sh
+        eng/ci/scripts/build-all.sh
       displayName: 'Build all Go modules'
 

--- a/eng/ci/templates/jobs/codeql.yml
+++ b/eng/ci/templates/jobs/codeql.yml
@@ -1,0 +1,61 @@
+# ============================================================
+# Dedicated CodeQL job for the Go worker.
+#
+# Why this exists:
+#   CodeQL 3000 traces the compiler to build a database. On Linux,
+#   Go 1.21+ binaries are statically linked, so the CodeQL tracer
+#   can no longer intercept `go build` — a traced build produces
+#   an empty database. See:
+#   https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/onboarding/language-compiled
+#
+#   The 1ES-recommended fix for Go 1.21+ is to run CodeQL in a
+#   separate job with `Codeql.BuildMode: autobuild`. The Go
+#   autobuilder discovers every go.mod under the source root and
+#   runs `go build ./...` per module without needing tracing.
+#
+# What this job does:
+#   Installs Go, then hands off to the auto-injected CodeQL 3000
+#   Init/Finalize tasks. The autobuilder does the actual build.
+# ============================================================
+
+parameters:
+  - name: PoolName
+    type: string
+    default: 1es-pool-azfunc-public
+
+jobs:
+  - job: codeql
+    displayName: 'CodeQL Scan (Go)'
+    # Give CodeQL 3000 Finalize enough time to zip + upload the
+    # database and log artifacts.
+    cancelTimeoutInMinutes: 45
+
+    pool:
+      name: ${{ parameters.PoolName }}
+      image: 1es-ubuntu-22.04
+      os: linux
+
+    variables:
+      # Autobuild lets the CodeQL Go extractor build every go.mod
+      # module itself, sidestepping the Go 1.21+ static-binary
+      # tracing issue.
+      Codeql.BuildMode: autobuild
+      # Run CodeQL on every trigger of this pipeline. Default
+      # cadence (72h) would skip most PR/CI runs.
+      Codeql.Cadence: 0
+      # Publish CodeQL CLI logs and the resulting database as
+      # pipeline artifacts for debugging.
+      Codeql.PublishDatabaseLog: true
+      Codeql.PublishDatabase: true
+
+    steps:
+    - task: GoTool@0
+      displayName: 'Install Go 1.25'
+      inputs:
+        version: '1.25'
+
+    # Placeholder step. The CodeQL 3000 Init and Finalize tasks
+    # are auto-injected by the 1ES template around user steps;
+    # the Go autobuilder runs between them.
+    - script: echo "CodeQL scan for autobuild go"
+      displayName: 'CodeQL autobuild marker'


### PR DESCRIPTION
## Summary
CodeQL for the Go worker now runs in its own job using `autobuild` mode. This works around the Go 1.21+ static-binary tracing issue, where CodeQL 3000's traced `go build` silently produces an empty database on Linux. The Build job goes back to a plain build with auto-injected CodeQL disabled.

See [1ES CodeQL Go guidance](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/onboarding/language-compiled).

## Changes

| File | Change |
| --- | --- |
| `eng/ci/templates/jobs/codeql.yml` | **New.** Dedicated CodeQL job: installs Go 1.25, sets `Codeql.BuildMode: autobuild`, `Codeql.Cadence: 0`, publishes DB + logs. |
| `eng/ci/templates/jobs/build.yml` | Removed tracing workaround and CodeQL variables. Disables auto-injected CodeQL via `templateContext.sdl.codeql.compiled.enabled: false`. Drops samples build step. |
| `eng/ci/official-build.yml` | Adds parallel `CodeQL` stage (`dependsOn: []`) referencing `codeql.yml`. |
| `eng/ci/public-build.yml` | Adds parallel `CodeQL` stage. Enables `analyzeInPipeline: true` on PRs to `main` so SARIF is viewable pre-merge. |
| `eng/ci/scripts/codeql-build.sh` → `build-all.sh` | Renamed and simplified. No longer builds `samples/*` or needs tracing hooks. |
| `CodeQL.yml` | Trimmed comments. Samples fully excluded via `queries.exclude` (not built in CI) instead of classified as `library`. |

## Notes
- PR-mode analysis does **not** upload to CAP Central; the default-branch official run remains the compliance source of truth.
- `cancelTimeoutInMinutes: 45` moved from Build to the new CodeQL job (that's where Finalize now runs).
