### PR TITLE
worker: wait for gRPC READY before opening EventStream

### DIFF
--- a/internal/hostclient/hostclient.go
+++ b/internal/hostclient/hostclient.go
@@ -12,10 +12,11 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-// connectionTimeout matches the Functions host's default ProcessStartupTimeout.
-// Using the full host startup budget avoids terminating a recoverable connection
-// early, which would add the host's ProcessRestartInterval to the cold start.
-const connectionTimeout = 60 * time.Second
+// connectionTimeout stays below the Functions host's 60-second
+// ProcessStartupTimeout so readiness failures can be logged before the host
+// terminates the worker. The remaining budget covers EventStream setup and the
+// StartStream handshake.
+const connectionTimeout = 50 * time.Second
 
 var connectParams = grpc.ConnectParams{
 	Backoff: backoff.Config{

--- a/internal/hostclient/hostclient.go
+++ b/internal/hostclient/hostclient.go
@@ -1,0 +1,104 @@
+package hostclient
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// connectionTimeout matches the Functions host's default ProcessStartupTimeout.
+// Using the full host startup budget avoids terminating a recoverable connection
+// early, which would add the host's ProcessRestartInterval to the cold start.
+const connectionTimeout = 60 * time.Second
+
+var connectParams = grpc.ConnectParams{
+	Backoff: backoff.Config{
+		BaseDelay:  100 * time.Millisecond,
+		Multiplier: 1.6,
+		Jitter:     0.2,
+		MaxDelay:   500 * time.Millisecond,
+	},
+	MinConnectTimeout: time.Second,
+}
+
+// OpenEventStream connects to the local Functions host and opens its RPC event
+// stream. The insecure transport preserves the existing worker-host protocol.
+func OpenEventStream(address string, maxMessageSize int) (grpc.BidiStreamingClient[pb.StreamingMessage, pb.StreamingMessage], error) {
+	conn, err := grpc.NewClient(
+		address,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxMessageSize),
+			grpc.MaxCallSendMsgSize(maxMessageSize),
+		),
+		grpc.WithConnectParams(connectParams),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create gRPC client: %w", err)
+	}
+
+	return openEventStream(conn, connectionTimeout)
+}
+
+func openEventStream(conn hostConnection, timeout time.Duration) (grpc.BidiStreamingClient[pb.StreamingMessage, pb.StreamingMessage], error) {
+	if err := waitForReady(conn, timeout); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
+	stream, err := pb.NewFunctionRpcClient(conn).EventStream(context.Background())
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("open gRPC EventStream: %w", err)
+	}
+	return stream, nil
+}
+
+func waitForReady(conn readyConnection, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	conn.Connect()
+	for {
+		state := conn.GetState()
+		switch state {
+		case connectivity.Ready:
+			return nil
+		case connectivity.Shutdown:
+			// A freshly created connection should not reach Shutdown on the
+			// current call path, but it is terminal for any future callers.
+			return fmt.Errorf("gRPC connection is in terminal state %s and cannot become ready", state)
+		}
+
+		if !conn.WaitForStateChange(ctx, state) {
+			return fmt.Errorf(
+				"timed out after %s waiting for gRPC connection to become ready (last state: %s): %w",
+				timeout,
+				state,
+				ctx.Err(),
+			)
+		}
+	}
+}
+
+// readyConnection is the subset of grpc.ClientConn used by waitForReady to
+// activate the lazy connection and observe connectivity state transitions.
+type readyConnection interface {
+	Connect()
+	GetState() connectivity.State
+	WaitForStateChange(context.Context, connectivity.State) bool
+}
+
+// hostConnection extends readyConnection with the operations openEventStream
+// needs to create the RPC stream and close the connection when setup fails.
+type hostConnection interface {
+	readyConnection
+	grpc.ClientConnInterface
+	Close() error
+}

--- a/internal/hostclient/hostclient_test.go
+++ b/internal/hostclient/hostclient_test.go
@@ -76,8 +76,8 @@ func (f *fakeConnection) pushState(state connectivity.State) {
 }
 
 func TestConnectionPolicy(t *testing.T) {
-	if connectionTimeout != 60*time.Second {
-		t.Fatalf("connectionTimeout = %s, want 60s", connectionTimeout)
+	if connectionTimeout != 50*time.Second {
+		t.Fatalf("connectionTimeout = %s, want 50s", connectionTimeout)
 	}
 	if connectParams.Backoff.BaseDelay != 100*time.Millisecond {
 		t.Fatalf("BaseDelay = %s, want 100ms", connectParams.Backoff.BaseDelay)

--- a/internal/hostclient/hostclient_test.go
+++ b/internal/hostclient/hostclient_test.go
@@ -1,0 +1,183 @@
+package hostclient
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+)
+
+type fakeConnection struct {
+	mu            sync.Mutex
+	state         connectivity.State
+	changeCh      chan struct{}
+	connectCalled atomic.Bool
+	closeCalled   atomic.Bool
+	newStreamErr  error
+}
+
+func newFakeConnection(state connectivity.State) *fakeConnection {
+	return &fakeConnection{
+		state:    state,
+		changeCh: make(chan struct{}, 1),
+	}
+}
+
+func (f *fakeConnection) Connect() {
+	f.connectCalled.Store(true)
+}
+
+func (f *fakeConnection) GetState() connectivity.State {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.state
+}
+
+func (f *fakeConnection) WaitForStateChange(ctx context.Context, sourceState connectivity.State) bool {
+	for {
+		if f.GetState() != sourceState {
+			return true
+		}
+		select {
+		case <-f.changeCh:
+		case <-ctx.Done():
+			return false
+		}
+	}
+}
+
+func (f *fakeConnection) Invoke(context.Context, string, any, any, ...grpc.CallOption) error {
+	return nil
+}
+
+func (f *fakeConnection) NewStream(context.Context, *grpc.StreamDesc, string, ...grpc.CallOption) (grpc.ClientStream, error) {
+	return nil, f.newStreamErr
+}
+
+func (f *fakeConnection) Close() error {
+	f.closeCalled.Store(true)
+	return nil
+}
+
+func (f *fakeConnection) pushState(state connectivity.State) {
+	f.mu.Lock()
+	f.state = state
+	f.mu.Unlock()
+	select {
+	case f.changeCh <- struct{}{}:
+	default:
+	}
+}
+
+func TestConnectionPolicy(t *testing.T) {
+	if connectionTimeout != 60*time.Second {
+		t.Fatalf("connectionTimeout = %s, want 60s", connectionTimeout)
+	}
+	if connectParams.Backoff.BaseDelay != 100*time.Millisecond {
+		t.Fatalf("BaseDelay = %s, want 100ms", connectParams.Backoff.BaseDelay)
+	}
+	if connectParams.Backoff.Multiplier != 1.6 {
+		t.Fatalf("Multiplier = %v, want 1.6", connectParams.Backoff.Multiplier)
+	}
+	if connectParams.Backoff.Jitter != 0.2 {
+		t.Fatalf("Jitter = %v, want 0.2", connectParams.Backoff.Jitter)
+	}
+	if connectParams.Backoff.MaxDelay != 500*time.Millisecond {
+		t.Fatalf("MaxDelay = %s, want 500ms", connectParams.Backoff.MaxDelay)
+	}
+	if connectParams.MinConnectTimeout != time.Second {
+		t.Fatalf("MinConnectTimeout = %s, want 1s", connectParams.MinConnectTimeout)
+	}
+}
+
+func TestWaitForReady_ConnectsAndObservesStateChanges(t *testing.T) {
+	conn := newFakeConnection(connectivity.Idle)
+	go func() {
+		conn.pushState(connectivity.Connecting)
+		conn.pushState(connectivity.Ready)
+	}()
+
+	if err := waitForReady(conn, time.Second); err != nil {
+		t.Fatalf("waitForReady() error = %v", err)
+	}
+	if !conn.connectCalled.Load() {
+		t.Fatal("waitForReady() did not call Connect()")
+	}
+}
+
+func TestWaitForReady_ReturnsImmediatelyWhenReady(t *testing.T) {
+	conn := newFakeConnection(connectivity.Ready)
+
+	if err := waitForReady(conn, time.Second); err != nil {
+		t.Fatalf("waitForReady() error = %v", err)
+	}
+	if !conn.connectCalled.Load() {
+		t.Fatal("waitForReady() did not call Connect()")
+	}
+}
+
+func TestWaitForReady_TimesOutWithLastStateAndWrappedDeadline(t *testing.T) {
+	conn := newFakeConnection(connectivity.TransientFailure)
+
+	err := waitForReady(conn, 20*time.Millisecond)
+
+	if err == nil {
+		t.Fatal("waitForReady() error = nil, want timeout")
+	}
+	if !strings.Contains(err.Error(), connectivity.TransientFailure.String()) {
+		t.Fatalf("error %q does not include last state", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error %q does not wrap context.DeadlineExceeded", err)
+	}
+}
+
+func TestWaitForReady_FailsFastOnShutdown(t *testing.T) {
+	conn := newFakeConnection(connectivity.Shutdown)
+
+	err := waitForReady(conn, time.Second)
+
+	if err == nil {
+		t.Fatal("waitForReady() error = nil, want terminal state error")
+	}
+	if !strings.Contains(err.Error(), connectivity.Shutdown.String()) {
+		t.Fatalf("error %q does not include Shutdown", err)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Shutdown error wraps context.DeadlineExceeded: %v", err)
+	}
+}
+
+func TestOpenEventStream_ClosesConnectionWhenReadinessFails(t *testing.T) {
+	conn := newFakeConnection(connectivity.Shutdown)
+
+	_, err := openEventStream(conn, time.Second)
+
+	if err == nil {
+		t.Fatal("openEventStream() error = nil, want readiness failure")
+	}
+	if !conn.closeCalled.Load() {
+		t.Fatal("openEventStream() did not close connection after readiness failure")
+	}
+}
+
+func TestOpenEventStream_ClosesConnectionWhenStreamCreationFails(t *testing.T) {
+	streamErr := errors.New("stream creation failed")
+	conn := newFakeConnection(connectivity.Ready)
+	conn.newStreamErr = streamErr
+
+	_, err := openEventStream(conn, time.Second)
+
+	if !errors.Is(err, streamErr) {
+		t.Fatalf("openEventStream() error = %v, want %v", err, streamErr)
+	}
+	if !conn.closeCalled.Load() {
+		t.Fatal("openEventStream() did not close connection after stream creation failure")
+	}
+}

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"log"
@@ -14,10 +13,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/azure/azure-functions-golang-worker/internal/hostclient"
 	"github.com/azure/azure-functions-golang-worker/worker"
 	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 const defaultAppDir = "/home/site/wwwroot"
@@ -36,7 +35,6 @@ func appBinaryPath(dir string) string {
 type Proxy struct {
 	pb.UnimplementedFunctionRpcServer
 
-	hostClient pb.FunctionRpcClient
 	hostStream grpc.BidiStreamingClient[pb.StreamingMessage, pb.StreamingMessage]
 
 	childStream    pb.FunctionRpc_EventStreamServer
@@ -127,21 +125,13 @@ func main() {
 }
 
 func (p *Proxy) connectToHost() error {
-	opts := []grpc.DialOption{
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(p.config.FunctionsGrpcMaxMessageLength),
-			grpc.MaxCallSendMsgSize(p.config.FunctionsGrpcMaxMessageLength),
-		),
-	}
+	return p.connectToHostWith(hostclient.OpenEventStream)
+}
 
-	conn, err := grpc.NewClient(p.config.FunctionsUri, opts...)
-	if err != nil {
-		return err
-	}
+type hostStreamOpener func(string, int) (grpc.BidiStreamingClient[pb.StreamingMessage, pb.StreamingMessage], error)
 
-	p.hostClient = pb.NewFunctionRpcClient(conn)
-	stream, err := p.hostClient.EventStream(context.Background())
+func (p *Proxy) connectToHostWith(open hostStreamOpener) error {
+	stream, err := open(p.config.FunctionsUri, p.config.FunctionsGrpcMaxMessageLength)
 	if err != nil {
 		return err
 	}

--- a/proxy/main_test.go
+++ b/proxy/main_test.go
@@ -1,11 +1,99 @@
 package main
 
 import (
+	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/azure/azure-functions-golang-worker/worker"
+	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
+
+type recordingHostStream struct {
+	mu   sync.Mutex
+	sent []*pb.StreamingMessage
+}
+
+func TestConnectToHostWith_UsesSharedStreamAndSendsProxyStartMessage(t *testing.T) {
+	stream := &recordingHostStream{}
+	config := &worker.WorkerStartupConfig{
+		FunctionsUri:                  "host:1234",
+		FunctionsWorkerId:             "worker-id",
+		FunctionsRequestId:            "request-id",
+		FunctionsGrpcMaxMessageLength: 1024,
+	}
+	proxy := &Proxy{config: config}
+	open := func(address string, maxMessageSize int) (grpc.BidiStreamingClient[pb.StreamingMessage, pb.StreamingMessage], error) {
+		if address != config.FunctionsUri {
+			t.Fatalf("address = %q, want %q", address, config.FunctionsUri)
+		}
+		if maxMessageSize != config.FunctionsGrpcMaxMessageLength {
+			t.Fatalf("maxMessageSize = %d, want %d", maxMessageSize, config.FunctionsGrpcMaxMessageLength)
+		}
+		return stream, nil
+	}
+
+	if err := proxy.connectToHostWith(open); err != nil {
+		t.Fatalf("connectToHostWith() error = %v", err)
+	}
+	if proxy.hostStream != stream {
+		t.Fatal("proxy hostStream was not set to the shared stream")
+	}
+
+	stream.mu.Lock()
+	defer stream.mu.Unlock()
+	if len(stream.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(stream.sent))
+	}
+	msg := stream.sent[0]
+	if msg.RequestId != config.FunctionsRequestId {
+		t.Fatalf("request ID = %q, want %q", msg.RequestId, config.FunctionsRequestId)
+	}
+	if msg.GetStartStream().GetWorkerId() != config.FunctionsWorkerId {
+		t.Fatalf("worker ID = %q, want %q", msg.GetStartStream().GetWorkerId(), config.FunctionsWorkerId)
+	}
+}
+
+func (s *recordingHostStream) Send(msg *pb.StreamingMessage) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sent = append(s.sent, msg)
+	return nil
+}
+
+func (s *recordingHostStream) Recv() (*pb.StreamingMessage, error) {
+	return nil, io.EOF
+}
+
+func (s *recordingHostStream) Header() (metadata.MD, error) {
+	return nil, nil
+}
+
+func (s *recordingHostStream) Trailer() metadata.MD {
+	return nil
+}
+
+func (s *recordingHostStream) CloseSend() error {
+	return nil
+}
+
+func (s *recordingHostStream) Context() context.Context {
+	return context.Background()
+}
+
+func (s *recordingHostStream) SendMsg(any) error {
+	return nil
+}
+
+func (s *recordingHostStream) RecvMsg(any) error {
+	return io.EOF
+}
 
 func TestAppBinaryPath_Default(t *testing.T) {
 	os.Unsetenv("FUNCTIONS_APP_BINARY_NAME")

--- a/worker/grpc.go
+++ b/worker/grpc.go
@@ -7,24 +7,23 @@ import (
 	"log/slog"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-// outboundQueueSize is the buffered size of the channel used by the gRPC
-// sender goroutine. Sized for typical Functions workloads where a single
-// invocation might emit a handful of logs plus the response message; the
-// host drains messages quickly enough that backpressure is rare.
+// outboundQueueSize is the capacity, in messages, of the buffered channel
+// feeding the gRPC sender goroutine. Each slot holds one *pb.StreamingMessage
+// (a response or a log line). Sized generously; the host drains fast enough
+// that backpressure is rare.
 const outboundQueueSize = 256
 
-// streamSender is a goroutine-safe push onto the worker's outbound gRPC
-// queue. Returned by [startSender]; passed wherever a response or log
-// message needs to leave the worker. The signature matches what
-// [log.NewWriter] accepts as its send parameter, so the worker can wire
-// the same function into both the dispatcher and the log writer.
+// streamSender enqueues a message onto the worker's outbound gRPC queue.
+// Safe for concurrent use. Its signature matches what [log.NewWriter] expects.
 type streamSender func(*pb.StreamingMessage) error
 
 func connectToHost(hostAddress string, maxMsgSize int, workerId string) (
@@ -51,12 +50,54 @@ func getBidiStreamClient(address string, maxMsgSize int) (grpc.BidiStreamingClie
 		return nil, err
 	}
 
+	// Drive the connection to READY before opening the stream. Otherwise
+	// EventStream would fast-fail if the host isn't listening yet, which
+	// happens when the host launches the worker as part of its startup.
+	if err := waitForConnReady(conn, connectTimeout); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
 	client := pb.NewFunctionRpcClient(conn)
 	return client.EventStream(context.Background())
 }
 
-// sendStartStreamMessage establishes the worker -> host handshake. After
-// it returns, the host sends WorkerInitRequest.
+// connectTimeout bounds the initial wait for the host's gRPC server. If it
+// isn't listening within this window, fail loudly instead of hanging.
+const connectTimeout = 5 * time.Second
+
+// waitForConnReady blocks until conn reaches connectivity.Ready or the
+// timeout expires. gRPC handles dial retries and backoff internally.
+func waitForConnReady(conn readyConn, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// grpc.NewClient is lazy: the connection stays in IDLE until the first
+	// RPC. Without this call the loop below has nothing to observe and
+	// every startup would hang for the full connectTimeout.
+	conn.Connect()
+	for {
+		state := conn.GetState()
+		if state == connectivity.Ready {
+			return nil
+		}
+		if !conn.WaitForStateChange(ctx, state) {
+			return fmt.Errorf("timed out after %s waiting for gRPC connection to become ready (last state: %s): %w",
+				timeout, state, ctx.Err())
+		}
+	}
+}
+
+// readyConn is the subset of *grpc.ClientConn used by waitForConnReady,
+// carved out so tests can supply a fake.
+type readyConn interface {
+	Connect()
+	GetState() connectivity.State
+	WaitForStateChange(ctx context.Context, sourceState connectivity.State) bool
+}
+
+// sendStartStreamMessage performs the worker -> host handshake, after which
+// the host sends WorkerInitRequest.
 func sendStartStreamMessage(client grpc.BidiStreamingClient[pb.StreamingMessage, pb.StreamingMessage], workerId string) error {
 	startStreamMsg := &pb.StreamingMessage{
 		Content: &pb.StreamingMessage_StartStream{
@@ -68,39 +109,32 @@ func sendStartStreamMessage(client grpc.BidiStreamingClient[pb.StreamingMessage,
 	return client.Send(startStreamMsg)
 }
 
-// startSender owns the gRPC ClientStream's Send call. gRPC's Send is not
-// safe for concurrent use, so we serialize all writes through a single
-// goroutine that drains a buffered channel.
+// startSender serializes writes to the gRPC stream. grpc.ClientStream.Send
+// is not safe for concurrent use, so every message goes through a single
+// goroutine draining a buffered channel.
 //
 // Returns:
-//   - send: a goroutine-safe enqueue function. Pass it to LogWriter and
-//     anywhere a response message needs to be emitted.
-//   - stop: shuts the sender goroutine down. Safe to call any number of
-//     times concurrently; only the first call closes the queue.
-//   - done: closed when the sender goroutine has exited (either because
-//     stop was called or because Send returned an error). Callers may
-//     wait on it to know the gRPC stream is no longer usable.
+//   - send: enqueues a message; safe for concurrent callers.
+//   - stop: shuts the sender down. Idempotent.
+//   - done: closed once the sender goroutine has exited (via stop or a
+//     Send error). Signals that the gRPC stream is no longer usable.
 //
-// When client.Send returns an error the sender logs it through the
-// supplied bootstrap handler (so we don't deadlock by recursing through
-// the LogWriter) and exits. Subsequent enqueues become no-ops returning
-// the captured error.
+// On Send failure the sender logs via errLogger — not the LogWriter, which
+// would recurse back through this same sender — and exits. Later enqueues
+// return io.ErrClosedPipe.
 func startSender(client grpc.BidiStreamingClient[pb.StreamingMessage, pb.StreamingMessage], errLogger *slog.Logger) (send streamSender, stop func(), done <-chan struct{}) {
 	queue := make(chan *pb.StreamingMessage, outboundQueueSize)
 	finished := make(chan struct{})
 
-	// stop is a close-once channel that signals shutdown to all senders.
-	// It allows multiple concurrent readers (sendFn calls) to detect shutdown
-	// without races. The sender goroutine drains the queue after stop is
-	// closed, ensuring no messages are lost.
+	// stopChan is close-once so multiple sendFn callers can detect shutdown
+	// without racing. closed is a fast-path check that avoids a channel op
+	// on the hot enqueue path.
 	stopChan := make(chan struct{})
 	var stopOnce sync.Once
 	var closed atomic.Bool
 
 	go func() {
 		defer close(finished)
-		// Sender goroutine: dequeue and forward messages until stopChan closes
-		// or a gRPC send error occurs.
 		for {
 			select {
 			case <-stopChan:
@@ -140,7 +174,6 @@ func startSender(client grpc.BidiStreamingClient[pb.StreamingMessage, pb.Streami
 		}
 		select {
 		case <-stopChan:
-			// Shutdown has started; return immediately without queuing.
 			return io.ErrClosedPipe
 		case queue <- m:
 			return nil

--- a/worker/grpc.go
+++ b/worker/grpc.go
@@ -81,6 +81,14 @@ func waitForConnReady(conn readyConn, timeout time.Duration) error {
 		if state == connectivity.Ready {
 			return nil
 		}
+		// Shutdown is terminal — the channel can never become Ready again,
+		// so waiting for the full timeout would only add startup latency
+		// and hide the real failure. Idle/Connecting/TransientFailure are
+		// all recoverable; gRPC drives its own retries and backoff between
+		// them, so we just keep observing.
+		if state == connectivity.Shutdown {
+			return fmt.Errorf("gRPC connection is in terminal state %s and cannot become ready", state)
+		}
 		if !conn.WaitForStateChange(ctx, state) {
 			return fmt.Errorf("timed out after %s waiting for gRPC connection to become ready (last state: %s): %w",
 				timeout, state, ctx.Err())

--- a/worker/grpc.go
+++ b/worker/grpc.go
@@ -7,13 +7,11 @@ import (
 	"log/slog"
 	"sync"
 	"sync/atomic"
-	"time"
 
+	"github.com/azure/azure-functions-golang-worker/internal/hostclient"
 	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 // outboundQueueSize is the capacity, in messages, of the buffered channel
@@ -28,80 +26,23 @@ type streamSender func(*pb.StreamingMessage) error
 
 func connectToHost(hostAddress string, maxMsgSize int, workerId string) (
 	grpc.BidiStreamingClient[pb.StreamingMessage, pb.StreamingMessage], error) {
-	client, err := getBidiStreamClient(hostAddress, maxMsgSize)
+	return connectToHostWith(hostAddress, maxMsgSize, workerId, hostclient.OpenEventStream)
+}
+
+type hostStreamOpener func(string, int) (grpc.BidiStreamingClient[pb.StreamingMessage, pb.StreamingMessage], error)
+
+func connectToHostWith(hostAddress string, maxMsgSize int, workerId string, open hostStreamOpener) (
+	grpc.BidiStreamingClient[pb.StreamingMessage, pb.StreamingMessage], error) {
+	client, err := open(hostAddress, maxMsgSize)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to gRPC stream: %v", err)
+		return nil, fmt.Errorf("failed to connect to gRPC stream: %w", err)
 	}
 
 	if err := sendStartStreamMessage(client, workerId); err != nil {
-		return nil, fmt.Errorf("failed to send start stream message: %v", err)
+		return nil, fmt.Errorf("failed to send start stream message: %w", err)
 	}
 
 	return client, nil
-}
-
-func getBidiStreamClient(address string, maxMsgSize int) (grpc.BidiStreamingClient[pb.StreamingMessage, pb.StreamingMessage], error) {
-	opts := []grpc.DialOption{
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize), grpc.MaxCallSendMsgSize(maxMsgSize)),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	}
-	conn, err := grpc.NewClient(address, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	// Drive the connection to READY before opening the stream. Otherwise
-	// EventStream would fast-fail if the host isn't listening yet, which
-	// happens when the host launches the worker as part of its startup.
-	if err := waitForConnReady(conn, connectTimeout); err != nil {
-		_ = conn.Close()
-		return nil, err
-	}
-
-	client := pb.NewFunctionRpcClient(conn)
-	return client.EventStream(context.Background())
-}
-
-// connectTimeout bounds the initial wait for the host's gRPC server. If it
-// isn't listening within this window, fail loudly instead of hanging.
-const connectTimeout = 5 * time.Second
-
-// waitForConnReady blocks until conn reaches connectivity.Ready or the
-// timeout expires. gRPC handles dial retries and backoff internally.
-func waitForConnReady(conn readyConn, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	// grpc.NewClient is lazy: the connection stays in IDLE until the first
-	// RPC. Without this call the loop below has nothing to observe and
-	// every startup would hang for the full connectTimeout.
-	conn.Connect()
-	for {
-		state := conn.GetState()
-		if state == connectivity.Ready {
-			return nil
-		}
-		// Shutdown is terminal — the channel can never become Ready again,
-		// so waiting for the full timeout would only add startup latency
-		// and hide the real failure. Idle/Connecting/TransientFailure are
-		// all recoverable; gRPC drives its own retries and backoff between
-		// them, so we just keep observing.
-		if state == connectivity.Shutdown {
-			return fmt.Errorf("gRPC connection is in terminal state %s and cannot become ready", state)
-		}
-		if !conn.WaitForStateChange(ctx, state) {
-			return fmt.Errorf("timed out after %s waiting for gRPC connection to become ready (last state: %s): %w",
-				timeout, state, ctx.Err())
-		}
-	}
-}
-
-// readyConn is the subset of *grpc.ClientConn used by waitForConnReady,
-// carved out so tests can supply a fake.
-type readyConn interface {
-	Connect()
-	GetState() connectivity.State
-	WaitForStateChange(ctx context.Context, sourceState connectivity.State) bool
 }
 
 // sendStartStreamMessage performs the worker -> host handshake, after which

--- a/worker/grpc_test.go
+++ b/worker/grpc_test.go
@@ -3,15 +3,15 @@ package worker
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
-	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
-	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -100,157 +100,15 @@ func TestStartSender_SendErrorClosesDoneAndRejectsFutureSends(t *testing.T) {
 	}
 }
 
-// fakeReadyConn drives waitForConnReady in tests without needing a real gRPC
-// client. GetState() returns the most recently pushed state (matching gRPC's
-// "current state" semantics — nothing is consumed). WaitForStateChange blocks,
-// respecting ctx, until a state different from sourceState has been pushed or
-// the deadline expires. This models gRPC's own state-notification semantics
-// closely enough for the retry-timing tests.
-type fakeReadyConn struct {
-	mu             sync.Mutex
-	states         []connectivity.State
-	changeCh       chan struct{}
-	connectCalled  bool
-}
-
-func newFakeReadyConn(initial connectivity.State) *fakeReadyConn {
-	return &fakeReadyConn{
-		states:   []connectivity.State{initial},
-		changeCh: make(chan struct{}, 16),
+func TestConnectToHost_PreservesOpenStreamError(t *testing.T) {
+	openErr := fmt.Errorf("open stream: %w", context.DeadlineExceeded)
+	open := func(string, int) (grpc.BidiStreamingClient[pb.StreamingMessage, pb.StreamingMessage], error) {
+		return nil, openErr
 	}
-}
 
-func (f *fakeReadyConn) Connect() {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.connectCalled = true
-}
+	_, err := connectToHostWith("host", 1024, "worker-id", open)
 
-func (f *fakeReadyConn) GetState() connectivity.State {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.states[len(f.states)-1]
-}
-
-func (f *fakeReadyConn) WaitForStateChange(ctx context.Context, sourceState connectivity.State) bool {
-	// Loop until the observed state differs from sourceState, or ctx expires.
-	for {
-		f.mu.Lock()
-		current := f.states[len(f.states)-1]
-		f.mu.Unlock()
-		if current != sourceState {
-			return true
-		}
-		select {
-		case <-f.changeCh:
-			// A new state was pushed; loop to re-read.
-		case <-ctx.Done():
-			return false
-		}
-	}
-}
-
-// pushState appends a new state and wakes anyone parked in WaitForStateChange.
-func (f *fakeReadyConn) pushState(s connectivity.State) {
-	f.mu.Lock()
-	f.states = append(f.states, s)
-	f.mu.Unlock()
-	select {
-	case f.changeCh <- struct{}{}:
-	default:
-	}
-}
-
-func TestWaitForConnReady_ReturnsWhenReady(t *testing.T) {
-	conn := newFakeReadyConn(connectivity.Idle)
-
-	// Simulate the host coming up shortly after the worker starts to dial:
-	// IDLE -> CONNECTING -> READY.
-	go func() {
-		time.Sleep(20 * time.Millisecond)
-		conn.pushState(connectivity.Connecting)
-		time.Sleep(20 * time.Millisecond)
-		conn.pushState(connectivity.Ready)
-	}()
-
-	start := time.Now()
-	if err := waitForConnReady(conn, 2*time.Second); err != nil {
-		t.Fatalf("expected nil, got %v", err)
-	}
-	if elapsed := time.Since(start); elapsed > time.Second {
-		t.Fatalf("waited too long for ready state: %s", elapsed)
-	}
-	if !conn.connectCalled {
-		t.Fatal("Connect() was not called to nudge the conn out of IDLE")
-	}
-}
-
-func TestWaitForConnReady_AlreadyReady(t *testing.T) {
-	// If the channel is already Ready when we check, waitForConnReady
-	// should return immediately without waiting for any state change.
-	conn := newFakeReadyConn(connectivity.Ready)
-
-	start := time.Now()
-	if err := waitForConnReady(conn, 2*time.Second); err != nil {
-		t.Fatalf("expected nil, got %v", err)
-	}
-	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
-		t.Fatalf("already-ready conn should return immediately, took %s", elapsed)
-	}
-	if !conn.connectCalled {
-		t.Fatal("Connect() was not called")
-	}
-}
-
-func TestWaitForConnReady_TimesOutWhenNeverReady(t *testing.T) {
-	// Conn parked in TRANSIENT_FAILURE and never recovers — models the host
-	// being unreachable for the full timeout window.
-	conn := newFakeReadyConn(connectivity.TransientFailure)
-
-	start := time.Now()
-	err := waitForConnReady(conn, 100*time.Millisecond)
-	elapsed := time.Since(start)
-
-	if err == nil {
-		t.Fatal("expected timeout error, got nil")
-	}
-	if !strings.Contains(err.Error(), "timed out") {
-		t.Fatalf("error should mention timeout, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), connectivity.TransientFailure.String()) {
-		t.Fatalf("error should include last observed state %q, got: %v",
-			connectivity.TransientFailure, err)
-	}
 	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("error should wrap context.DeadlineExceeded, got: %v", err)
-	}
-	if elapsed < 100*time.Millisecond {
-		t.Fatalf("returned before deadline elapsed: %s", elapsed)
-	}
-	if elapsed > 500*time.Millisecond {
-		t.Fatalf("returned well after deadline (leak?): %s", elapsed)
-	}
-}
-
-func TestWaitForConnReady_FailsFastOnShutdown(t *testing.T) {
-	// Shutdown is terminal — waitForConnReady must return immediately
-	// rather than waiting for the full timeout.
-	conn := newFakeReadyConn(connectivity.Shutdown)
-
-	start := time.Now()
-	err := waitForConnReady(conn, 5*time.Second)
-	elapsed := time.Since(start)
-
-	if err == nil {
-		t.Fatal("expected error for terminal Shutdown state, got nil")
-	}
-	if !strings.Contains(err.Error(), connectivity.Shutdown.String()) {
-		t.Fatalf("error should mention Shutdown state, got: %v", err)
-	}
-	if errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Shutdown should fail fast, not via deadline: %v", err)
-	}
-	if elapsed > 100*time.Millisecond {
-		t.Fatalf("Shutdown should return immediately, took %s", elapsed)
+		t.Fatalf("connectToHostWith() error = %v, want wrapped context.DeadlineExceeded", err)
 	}
 }

--- a/worker/grpc_test.go
+++ b/worker/grpc_test.go
@@ -101,10 +101,11 @@ func TestStartSender_SendErrorClosesDoneAndRejectsFutureSends(t *testing.T) {
 }
 
 // fakeReadyConn drives waitForConnReady in tests without needing a real gRPC
-// client. States are consumed in order: each GetState() pop reflects the next
-// scripted state, and WaitForStateChange blocks (respecting ctx) until either
-// another state is pushed or the deadline expires. This models gRPC's own
-// state-notification semantics closely enough for the retry-timing tests.
+// client. GetState() returns the most recently pushed state (matching gRPC's
+// "current state" semantics — nothing is consumed). WaitForStateChange blocks,
+// respecting ctx, until a state different from sourceState has been pushed or
+// the deadline expires. This models gRPC's own state-notification semantics
+// closely enough for the retry-timing tests.
 type fakeReadyConn struct {
 	mu             sync.Mutex
 	states         []connectivity.State
@@ -184,6 +185,23 @@ func TestWaitForConnReady_ReturnsWhenReady(t *testing.T) {
 	}
 }
 
+func TestWaitForConnReady_AlreadyReady(t *testing.T) {
+	// If the channel is already Ready when we check, waitForConnReady
+	// should return immediately without waiting for any state change.
+	conn := newFakeReadyConn(connectivity.Ready)
+
+	start := time.Now()
+	if err := waitForConnReady(conn, 2*time.Second); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+		t.Fatalf("already-ready conn should return immediately, took %s", elapsed)
+	}
+	if !conn.connectCalled {
+		t.Fatal("Connect() was not called")
+	}
+}
+
 func TestWaitForConnReady_TimesOutWhenNeverReady(t *testing.T) {
 	// Conn parked in TRANSIENT_FAILURE and never recovers — models the host
 	// being unreachable for the full timeout window.
@@ -199,6 +217,10 @@ func TestWaitForConnReady_TimesOutWhenNeverReady(t *testing.T) {
 	if !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("error should mention timeout, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), connectivity.TransientFailure.String()) {
+		t.Fatalf("error should include last observed state %q, got: %v",
+			connectivity.TransientFailure, err)
+	}
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("error should wrap context.DeadlineExceeded, got: %v", err)
 	}
@@ -207,5 +229,28 @@ func TestWaitForConnReady_TimesOutWhenNeverReady(t *testing.T) {
 	}
 	if elapsed > 500*time.Millisecond {
 		t.Fatalf("returned well after deadline (leak?): %s", elapsed)
+	}
+}
+
+func TestWaitForConnReady_FailsFastOnShutdown(t *testing.T) {
+	// Shutdown is terminal — waitForConnReady must return immediately
+	// rather than waiting for the full timeout.
+	conn := newFakeReadyConn(connectivity.Shutdown)
+
+	start := time.Now()
+	err := waitForConnReady(conn, 5*time.Second)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error for terminal Shutdown state, got nil")
+	}
+	if !strings.Contains(err.Error(), connectivity.Shutdown.String()) {
+		t.Fatalf("error should mention Shutdown state, got: %v", err)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Shutdown should fail fast, not via deadline: %v", err)
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Fatalf("Shutdown should return immediately, took %s", elapsed)
 	}
 }

--- a/worker/grpc_test.go
+++ b/worker/grpc_test.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -95,5 +97,115 @@ func TestStartSender_SendErrorClosesDoneAndRejectsFutureSends(t *testing.T) {
 
 	if err := send(&pb.StreamingMessage{}); !errors.Is(err, io.ErrClosedPipe) {
 		t.Fatalf("send after sender failure: got %v want %v", err, io.ErrClosedPipe)
+	}
+}
+
+// fakeReadyConn drives waitForConnReady in tests without needing a real gRPC
+// client. States are consumed in order: each GetState() pop reflects the next
+// scripted state, and WaitForStateChange blocks (respecting ctx) until either
+// another state is pushed or the deadline expires. This models gRPC's own
+// state-notification semantics closely enough for the retry-timing tests.
+type fakeReadyConn struct {
+	mu             sync.Mutex
+	states         []connectivity.State
+	changeCh       chan struct{}
+	connectCalled  bool
+}
+
+func newFakeReadyConn(initial connectivity.State) *fakeReadyConn {
+	return &fakeReadyConn{
+		states:   []connectivity.State{initial},
+		changeCh: make(chan struct{}, 16),
+	}
+}
+
+func (f *fakeReadyConn) Connect() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.connectCalled = true
+}
+
+func (f *fakeReadyConn) GetState() connectivity.State {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.states[len(f.states)-1]
+}
+
+func (f *fakeReadyConn) WaitForStateChange(ctx context.Context, sourceState connectivity.State) bool {
+	// Loop until the observed state differs from sourceState, or ctx expires.
+	for {
+		f.mu.Lock()
+		current := f.states[len(f.states)-1]
+		f.mu.Unlock()
+		if current != sourceState {
+			return true
+		}
+		select {
+		case <-f.changeCh:
+			// A new state was pushed; loop to re-read.
+		case <-ctx.Done():
+			return false
+		}
+	}
+}
+
+// pushState appends a new state and wakes anyone parked in WaitForStateChange.
+func (f *fakeReadyConn) pushState(s connectivity.State) {
+	f.mu.Lock()
+	f.states = append(f.states, s)
+	f.mu.Unlock()
+	select {
+	case f.changeCh <- struct{}{}:
+	default:
+	}
+}
+
+func TestWaitForConnReady_ReturnsWhenReady(t *testing.T) {
+	conn := newFakeReadyConn(connectivity.Idle)
+
+	// Simulate the host coming up shortly after the worker starts to dial:
+	// IDLE -> CONNECTING -> READY.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		conn.pushState(connectivity.Connecting)
+		time.Sleep(20 * time.Millisecond)
+		conn.pushState(connectivity.Ready)
+	}()
+
+	start := time.Now()
+	if err := waitForConnReady(conn, 2*time.Second); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("waited too long for ready state: %s", elapsed)
+	}
+	if !conn.connectCalled {
+		t.Fatal("Connect() was not called to nudge the conn out of IDLE")
+	}
+}
+
+func TestWaitForConnReady_TimesOutWhenNeverReady(t *testing.T) {
+	// Conn parked in TRANSIENT_FAILURE and never recovers — models the host
+	// being unreachable for the full timeout window.
+	conn := newFakeReadyConn(connectivity.TransientFailure)
+
+	start := time.Now()
+	err := waitForConnReady(conn, 100*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error should mention timeout, got: %v", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error should wrap context.DeadlineExceeded, got: %v", err)
+	}
+	if elapsed < 100*time.Millisecond {
+		t.Fatalf("returned before deadline elapsed: %s", elapsed)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("returned well after deadline (leak?): %s", elapsed)
 	}
 }


### PR DESCRIPTION
**What**
- Add shared `internal/hostclient` connection setup for both the worker and proxy.
- Drive lazy gRPC connections to `connectivity.Ready` before opening `EventStream`.
- Use a 50-second readiness timeout, leaving headroom within the host’s 60-second startup budget for stream setup and error logging.
- Configure faster reconnect backoff:
  - 100ms base delay
  - 1.6 multiplier
  - 20% jitter
  - 500ms maximum delay
  - 1-second minimum connect timeout
- Fail immediately if the connection reaches terminal `Shutdown`.
- Close the connection when readiness or stream creation fails.
- Preserve wrapped errors so callers can inspect failures with `errors.Is`.
- Apply the same behavior to the Flex proxy while retaining the worker- and proxy-specific `StartStream` messages.
- File #56 to track the pre-existing `startSender` queue-draining issue separately.

**Why**
`grpc.NewClient` creates a lazy connection. Opening `EventStream` immediately means a single transient connection failure can terminate the worker or proxy before gRPC reconnects.

Waiting for `READY` allows gRPC to retry within the host startup budget. The tuned backoff avoids long gaps between connection attempts, while the 50-second deadline leaves time for the timeout diagnostic to reach the logs before the host’s startup timeout expires.

**Tests**
- Verify the connection policy and 50-second timeout.
- Cover already-ready and state-transition paths.
- Verify `Connect()` activates the lazy connection.
- Verify timeouts include the last observed state and wrap `context.DeadlineExceeded`.
- Verify terminal `Shutdown` fails immediately.
- Verify failed readiness and stream creation close the connection.
- Verify worker error wrapping and proxy-specific `StartStream` behavior.
