### PR TITLE
Add strongly typed Event Hub and Service Bus batch triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ app.SQL("productsChanged", productsChanged,
     sdk.WithTable("dbo.Products"),
     sdk.WithConnection("AzureWebJobsSqlConnectionString"),
 )
+
+// Event Hub and Service Bus expose separate, strongly typed batch methods.
+app.EventHubBatch("processEvents", eventBatchHandler,
+    sdk.WithEventHubName("events"),
+    sdk.WithConnection("EventHubConnection"),
+)
+
+app.ServiceBusQueueBatch("processMessages", messageBatchHandler,
+    sdk.WithQueueName("messages"),
+    sdk.WithConnection("ServiceBusConnection"),
+)
 ```
 
 ### Extension Triggers (`triggers/`)

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ For work that matters (processing events, calling APIs), use [`sdk.RecoverTo`](s
 ```go
 import "golang.org/x/sync/errgroup"
 
-func EventHubHandler(ctx context.Context, events []bindings.EventHubEvent) error {
+func EventHubHandler(ctx context.Context, events []bindings.EventHubMessage) error {
     g, ctx := errgroup.WithContext(ctx)
     for _, e := range events {
         g.Go(func() (err error) {

--- a/samples/eventHubTrigger/host.json
+++ b/samples/eventHubTrigger/host.json
@@ -1,5 +1,12 @@
 {
   "version": "2.0",
+  "extensions": {
+    "eventHubs": {
+      "maxEventBatchSize": 2,
+      "minEventBatchSize": 2,
+      "maxWaitTime": "00:00:05"
+    }
+  },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[4.*, 5.0.0)"

--- a/samples/eventHubTrigger/main.go
+++ b/samples/eventHubTrigger/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/azure/azure-functions-golang-worker/sdk"
@@ -30,6 +31,7 @@ func EventHubBatchHandler(ctx context.Context, events []bindings.EventHubMessage
 			"sequence_number", event.SequenceNumber,
 			"offset", event.Offset,
 			"test_id", event.Properties["testID"],
+			"alignment_key", fmt.Sprintf("%s|%v", event.Body, event.Properties["testID"]),
 		)
 	}
 	return nil
@@ -43,7 +45,7 @@ func main() {
 		sdk.WithConnection("EventHubConnection"),
 		sdk.WithConsumerGroup("watchtower-test"),
 	)
-	app.EventHub("eventHubBatchTrigger", sdk.EventHubBatchHandler(EventHubBatchHandler),
+	app.EventHubBatch("eventHubBatchTrigger", EventHubBatchHandler,
 		sdk.WithEventHubName("input-hub-batch"),
 		sdk.WithConnection("EventHubConnection"),
 		sdk.WithConsumerGroup("watchtower-batch-test"),

--- a/samples/eventHubTrigger/main.go
+++ b/samples/eventHubTrigger/main.go
@@ -17,7 +17,21 @@ func EventHubHandler(ctx context.Context, event bindings.EventHubMessage) error 
 		"offset", event.Offset,
 		"enqueued_time", event.EnqueuedTimeUtc,
 		"partition_key", event.PartitionKey,
+		"test_id", event.Properties["testID"],
 	)
+	return nil
+}
+
+func EventHubBatchHandler(ctx context.Context, events []bindings.EventHubMessage) error {
+	slog.InfoContext(ctx, "eventhub batch trigger executed", "batch_size", len(events))
+	for _, event := range events {
+		slog.InfoContext(ctx, "eventhub batch event",
+			"body", string(event.Body),
+			"sequence_number", event.SequenceNumber,
+			"offset", event.Offset,
+			"test_id", event.Properties["testID"],
+		)
+	}
 	return nil
 }
 
@@ -28,6 +42,11 @@ func main() {
 		sdk.WithEventHubName("input-hub"),
 		sdk.WithConnection("EventHubConnection"),
 		sdk.WithConsumerGroup("watchtower-test"),
+	)
+	app.EventHub("eventHubBatchTrigger", sdk.EventHubBatchHandler(EventHubBatchHandler),
+		sdk.WithEventHubName("input-hub-batch"),
+		sdk.WithConnection("EventHubConnection"),
+		sdk.WithConsumerGroup("watchtower-batch-test"),
 	)
 
 	worker.Start(app)

--- a/samples/serviceBusQueueTrigger/host.json
+++ b/samples/serviceBusQueueTrigger/host.json
@@ -1,5 +1,12 @@
 {
   "version": "2.0",
+  "extensions": {
+    "serviceBus": {
+      "maxMessageBatchSize": 2,
+      "minMessageBatchSize": 2,
+      "maxBatchWaitTime": "00:00:05"
+    }
+  },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[4.*, 5.0.0)"

--- a/samples/serviceBusQueueTrigger/main.go
+++ b/samples/serviceBusQueueTrigger/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/azure/azure-functions-golang-worker/sdk"
@@ -31,6 +32,7 @@ func ServiceBusQueueBatchHandler(ctx context.Context, messages []bindings.Servic
 			"body", string(msg.Body),
 			"sequence_number", msg.SequenceNumber,
 			"test_id", msg.ApplicationProperties["testID"],
+			"alignment_key", fmt.Sprintf("%s|%s|%v", msg.Body, msg.MessageId, msg.ApplicationProperties["testID"]),
 		)
 	}
 	return nil
@@ -43,7 +45,7 @@ func main() {
 		sdk.WithQueueName("input-queue"),
 		sdk.WithConnection("ServiceBusConnection"),
 	)
-	app.ServiceBusQueue("queueBatchFunc", sdk.ServiceBusBatchHandler(ServiceBusQueueBatchHandler),
+	app.ServiceBusQueueBatch("queueBatchFunc", ServiceBusQueueBatchHandler,
 		sdk.WithQueueName("input-queue-batch"),
 		sdk.WithConnection("ServiceBusConnection"),
 	)

--- a/samples/serviceBusQueueTrigger/main.go
+++ b/samples/serviceBusQueueTrigger/main.go
@@ -18,7 +18,21 @@ func ServiceBusQueueHandler(ctx context.Context, msg bindings.ServiceBusMessage)
 		"sequence_number", msg.SequenceNumber,
 		"content_type", msg.ContentType,
 		"session_id", msg.SessionId,
+		"test_id", msg.ApplicationProperties["testID"],
 	)
+	return nil
+}
+
+func ServiceBusQueueBatchHandler(ctx context.Context, messages []bindings.ServiceBusMessage) error {
+	slog.InfoContext(ctx, "servicebus queue batch trigger executed", "batch_size", len(messages))
+	for _, msg := range messages {
+		slog.InfoContext(ctx, "servicebus queue batch message",
+			"message_id", msg.MessageId,
+			"body", string(msg.Body),
+			"sequence_number", msg.SequenceNumber,
+			"test_id", msg.ApplicationProperties["testID"],
+		)
+	}
 	return nil
 }
 
@@ -27,6 +41,10 @@ func main() {
 
 	app.ServiceBusQueue("queueFunc", ServiceBusQueueHandler,
 		sdk.WithQueueName("input-queue"),
+		sdk.WithConnection("ServiceBusConnection"),
+	)
+	app.ServiceBusQueue("queueBatchFunc", sdk.ServiceBusBatchHandler(ServiceBusQueueBatchHandler),
+		sdk.WithQueueName("input-queue-batch"),
 		sdk.WithConnection("ServiceBusConnection"),
 	)
 

--- a/samples/serviceBusTopicTrigger/host.json
+++ b/samples/serviceBusTopicTrigger/host.json
@@ -1,5 +1,12 @@
 {
   "version": "2.0",
+  "extensions": {
+    "serviceBus": {
+      "maxMessageBatchSize": 2,
+      "minMessageBatchSize": 2,
+      "maxBatchWaitTime": "00:00:05"
+    }
+  },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[4.*, 5.0.0)"

--- a/samples/serviceBusTopicTrigger/main.go
+++ b/samples/serviceBusTopicTrigger/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/azure/azure-functions-golang-worker/sdk"
@@ -23,12 +24,31 @@ func ServiceBusTopicHandler(ctx context.Context, msg bindings.ServiceBusMessage)
 	return nil
 }
 
+func ServiceBusTopicBatchHandler(ctx context.Context, messages []bindings.ServiceBusMessage) error {
+	slog.InfoContext(ctx, "servicebus topic batch trigger executed", "batch_size", len(messages))
+	for _, msg := range messages {
+		slog.InfoContext(ctx, "servicebus topic batch message",
+			"message_id", msg.MessageId,
+			"body", string(msg.Body),
+			"sequence_number", msg.SequenceNumber,
+			"test_id", msg.ApplicationProperties["testID"],
+			"alignment_key", fmt.Sprintf("%s|%s|%v", msg.Body, msg.MessageId, msg.ApplicationProperties["testID"]),
+		)
+	}
+	return nil
+}
+
 func main() {
 	app := sdk.FunctionApp()
 
 	app.ServiceBusTopic("topicFunc", ServiceBusTopicHandler,
 		sdk.WithTopicName("orders"),
 		sdk.WithSubscriptionName("processor"),
+		sdk.WithConnection("ServiceBusConnection"),
+	)
+	app.ServiceBusTopicBatch("topicBatchFunc", ServiceBusTopicBatchHandler,
+		sdk.WithTopicName("orders-batch"),
+		sdk.WithSubscriptionName("processor-batch"),
 		sdk.WithConnection("ServiceBusConnection"),
 	)
 

--- a/samples/serviceBusTopicTrigger/main.go
+++ b/samples/serviceBusTopicTrigger/main.go
@@ -18,6 +18,7 @@ func ServiceBusTopicHandler(ctx context.Context, msg bindings.ServiceBusMessage)
 		"sequence_number", msg.SequenceNumber,
 		"subject", msg.Subject,
 		"content_type", msg.ContentType,
+		"test_id", msg.ApplicationProperties["testID"],
 	)
 	return nil
 }

--- a/sdk/app.go
+++ b/sdk/app.go
@@ -106,69 +106,66 @@ func (app *App) Queue(name string, f QueueHandler, opts ...Option) *RegisteredFu
 	return app.registerFunction(name, f, trigger, opts...)
 }
 
-// EventHub creates a new EventHub triggered function. Use EventHubHandler for
-// single-event delivery or EventHubBatchHandler for batch delivery.
-func (app *App) EventHub(name string, f any, opts ...Option) *RegisteredFunction {
+// EventHub creates a new EventHub triggered function that receives one event
+// per invocation.
+func (app *App) EventHub(name string, f EventHubHandler, opts ...Option) *RegisteredFunction {
 	trigger := &bindings.EventHubTrigger{
 		Name:          "message",
 		ConsumerGroup: "$Default",
-		Cardinality:   validateMessageHandler("EventHub", f, reflect.TypeOf(bindings.EventHubMessage{})),
+		Cardinality:   "one",
 	}
 	return app.registerFunction(name, f, trigger, opts...)
 }
 
-// ServiceBusQueue creates a new Service Bus queue triggered function. Use
-// ServiceBusHandler for single-message delivery or ServiceBusBatchHandler for
-// batch delivery.
-func (app *App) ServiceBusQueue(name string, f any, opts ...Option) *RegisteredFunction {
+// EventHubBatch creates a new EventHub triggered function that receives a
+// batch of events per invocation.
+func (app *App) EventHubBatch(name string, f EventHubBatchHandler, opts ...Option) *RegisteredFunction {
+	trigger := &bindings.EventHubTrigger{
+		Name:          "message",
+		ConsumerGroup: "$Default",
+		Cardinality:   "many",
+	}
+	return app.registerFunction(name, f, trigger, opts...)
+}
+
+// ServiceBusQueue creates a new Service Bus queue triggered function that
+// receives one message per invocation.
+func (app *App) ServiceBusQueue(name string, f ServiceBusHandler, opts ...Option) *RegisteredFunction {
 	trigger := &bindings.ServiceBusQueueTrigger{
 		Name:        "message",
-		Cardinality: validateMessageHandler("ServiceBus", f, reflect.TypeOf(bindings.ServiceBusMessage{})),
+		Cardinality: "one",
 	}
 	return app.registerFunction(name, f, trigger, opts...)
 }
 
-// ServiceBusTopic creates a new Service Bus topic triggered function. Use
-// ServiceBusHandler for single-message delivery or ServiceBusBatchHandler for
-// batch delivery.
-func (app *App) ServiceBusTopic(name string, f any, opts ...Option) *RegisteredFunction {
+// ServiceBusQueueBatch creates a new Service Bus queue triggered function that
+// receives a batch of messages per invocation.
+func (app *App) ServiceBusQueueBatch(name string, f ServiceBusBatchHandler, opts ...Option) *RegisteredFunction {
+	trigger := &bindings.ServiceBusQueueTrigger{
+		Name:        "message",
+		Cardinality: "many",
+	}
+	return app.registerFunction(name, f, trigger, opts...)
+}
+
+// ServiceBusTopic creates a new Service Bus topic triggered function that
+// receives one message per invocation.
+func (app *App) ServiceBusTopic(name string, f ServiceBusHandler, opts ...Option) *RegisteredFunction {
 	trigger := &bindings.ServiceBusTopicTrigger{
 		Name:        "message",
-		Cardinality: validateMessageHandler("ServiceBus", f, reflect.TypeOf(bindings.ServiceBusMessage{})),
+		Cardinality: "one",
 	}
 	return app.registerFunction(name, f, trigger, opts...)
 }
 
-func validateMessageHandler(triggerName string, f any, messageType reflect.Type) string {
-	// Event Hub and Service Bus support two delivery experiences through the
-	// same registration API: one message per invocation or a batch of messages.
-	// Because callers can choose either shape, validate it when the function is
-	// registered so configuration mistakes fail immediately instead of at runtime.
-	ft := reflect.TypeOf(f)
-	if ft == nil || ft.Kind() != reflect.Func {
-		panic(fmt.Sprintf("%s handler must be a function", triggerName))
+// ServiceBusTopicBatch creates a new Service Bus topic triggered function that
+// receives a batch of messages per invocation.
+func (app *App) ServiceBusTopicBatch(name string, f ServiceBusBatchHandler, opts ...Option) *RegisteredFunction {
+	trigger := &bindings.ServiceBusTopicTrigger{
+		Name:        "message",
+		Cardinality: "many",
 	}
-
-	// Every trigger handler follows the same basic contract: Azure Functions
-	// provides the invocation context and payload, and the handler reports an error.
-	if ft.NumIn() != 2 || ft.In(0) != reflect.TypeOf((*context.Context)(nil)).Elem() {
-		panic(fmt.Sprintf("%s handler must accept (context.Context, message) or (context.Context, []message)", triggerName))
-	}
-	if ft.NumOut() != 1 || ft.Out(0) != reflect.TypeOf((*error)(nil)).Elem() {
-		panic(fmt.Sprintf("%s handler must return exactly one error", triggerName))
-	}
-
-	// The payload shape determines the cardinality sent to the Functions host.
-	// Keeping these in sync ensures the host sends exactly what the handler expects.
-	switch argumentType := ft.In(1); {
-	case argumentType == messageType:
-		return "one"
-	case argumentType.Kind() == reflect.Slice && argumentType.Elem() == messageType:
-		return "many"
-	default:
-		panic(fmt.Sprintf("%s handler second argument must be %s or []%s, got %s",
-			triggerName, messageType, messageType, argumentType))
-	}
+	return app.registerFunction(name, f, trigger, opts...)
 }
 
 // =============================================================================

--- a/sdk/app.go
+++ b/sdk/app.go
@@ -106,32 +106,69 @@ func (app *App) Queue(name string, f QueueHandler, opts ...Option) *RegisteredFu
 	return app.registerFunction(name, f, trigger, opts...)
 }
 
-// EventHub creates a new EventHub triggered function.
-func (app *App) EventHub(name string, f EventHubHandler, opts ...Option) *RegisteredFunction {
+// EventHub creates a new EventHub triggered function. Use EventHubHandler for
+// single-event delivery or EventHubBatchHandler for batch delivery.
+func (app *App) EventHub(name string, f any, opts ...Option) *RegisteredFunction {
 	trigger := &bindings.EventHubTrigger{
 		Name:          "message",
 		ConsumerGroup: "$Default",
-		Cardinality:   "one",
+		Cardinality:   validateMessageHandler("EventHub", f, reflect.TypeOf(bindings.EventHubMessage{})),
 	}
 	return app.registerFunction(name, f, trigger, opts...)
 }
 
-// ServiceBusQueue creates a new Service Bus queue triggered function.
-func (app *App) ServiceBusQueue(name string, f ServiceBusHandler, opts ...Option) *RegisteredFunction {
+// ServiceBusQueue creates a new Service Bus queue triggered function. Use
+// ServiceBusHandler for single-message delivery or ServiceBusBatchHandler for
+// batch delivery.
+func (app *App) ServiceBusQueue(name string, f any, opts ...Option) *RegisteredFunction {
 	trigger := &bindings.ServiceBusQueueTrigger{
 		Name:        "message",
-		Cardinality: "one",
+		Cardinality: validateMessageHandler("ServiceBus", f, reflect.TypeOf(bindings.ServiceBusMessage{})),
 	}
 	return app.registerFunction(name, f, trigger, opts...)
 }
 
-// ServiceBusTopic creates a new Service Bus topic triggered function.
-func (app *App) ServiceBusTopic(name string, f ServiceBusHandler, opts ...Option) *RegisteredFunction {
+// ServiceBusTopic creates a new Service Bus topic triggered function. Use
+// ServiceBusHandler for single-message delivery or ServiceBusBatchHandler for
+// batch delivery.
+func (app *App) ServiceBusTopic(name string, f any, opts ...Option) *RegisteredFunction {
 	trigger := &bindings.ServiceBusTopicTrigger{
 		Name:        "message",
-		Cardinality: "one",
+		Cardinality: validateMessageHandler("ServiceBus", f, reflect.TypeOf(bindings.ServiceBusMessage{})),
 	}
 	return app.registerFunction(name, f, trigger, opts...)
+}
+
+func validateMessageHandler(triggerName string, f any, messageType reflect.Type) string {
+	// Event Hub and Service Bus support two delivery experiences through the
+	// same registration API: one message per invocation or a batch of messages.
+	// Because callers can choose either shape, validate it when the function is
+	// registered so configuration mistakes fail immediately instead of at runtime.
+	ft := reflect.TypeOf(f)
+	if ft == nil || ft.Kind() != reflect.Func {
+		panic(fmt.Sprintf("%s handler must be a function", triggerName))
+	}
+
+	// Every trigger handler follows the same basic contract: Azure Functions
+	// provides the invocation context and payload, and the handler reports an error.
+	if ft.NumIn() != 2 || ft.In(0) != reflect.TypeOf((*context.Context)(nil)).Elem() {
+		panic(fmt.Sprintf("%s handler must accept (context.Context, message) or (context.Context, []message)", triggerName))
+	}
+	if ft.NumOut() != 1 || ft.Out(0) != reflect.TypeOf((*error)(nil)).Elem() {
+		panic(fmt.Sprintf("%s handler must return exactly one error", triggerName))
+	}
+
+	// The payload shape determines the cardinality sent to the Functions host.
+	// Keeping these in sync ensures the host sends exactly what the handler expects.
+	switch argumentType := ft.In(1); {
+	case argumentType == messageType:
+		return "one"
+	case argumentType.Kind() == reflect.Slice && argumentType.Elem() == messageType:
+		return "many"
+	default:
+		panic(fmt.Sprintf("%s handler second argument must be %s or []%s, got %s",
+			triggerName, messageType, messageType, argumentType))
+	}
 }
 
 // =============================================================================

--- a/sdk/app_test.go
+++ b/sdk/app_test.go
@@ -9,6 +9,15 @@ import (
 	"github.com/azure/azure-functions-golang-worker/sdk/bindings"
 )
 
+var (
+	_ func(*App, string, EventHubHandler, ...Option) *RegisteredFunction        = (*App).EventHub
+	_ func(*App, string, EventHubBatchHandler, ...Option) *RegisteredFunction   = (*App).EventHubBatch
+	_ func(*App, string, ServiceBusHandler, ...Option) *RegisteredFunction      = (*App).ServiceBusQueue
+	_ func(*App, string, ServiceBusBatchHandler, ...Option) *RegisteredFunction = (*App).ServiceBusQueueBatch
+	_ func(*App, string, ServiceBusHandler, ...Option) *RegisteredFunction      = (*App).ServiceBusTopic
+	_ func(*App, string, ServiceBusBatchHandler, ...Option) *RegisteredFunction = (*App).ServiceBusTopicBatch
+)
+
 // --- FunctionApp tests ---
 
 func TestFunctionApp(t *testing.T) {
@@ -838,7 +847,7 @@ func TestServiceBusQueue_WithCardinality(t *testing.T) {
 	app := FunctionApp()
 	handler := ServiceBusBatchHandler(func(ctx context.Context, msg []bindings.ServiceBusMessage) error { return nil })
 
-	app.ServiceBusQueue("sbCard", handler,
+	app.ServiceBusQueueBatch("sbCard", handler,
 		WithQueueName("card-queue"),
 		WithCardinality("many"),
 	)
@@ -860,12 +869,27 @@ func TestEventHub_BatchHandlerDefaultsToMany(t *testing.T) {
 	app := FunctionApp()
 	handler := EventHubBatchHandler(func(ctx context.Context, events []bindings.EventHubMessage) error { return nil })
 
-	app.EventHub("eventHubBatch", handler)
+	app.EventHubBatch("eventHubBatch", handler)
 
 	app.GetRegisteredFunctions().Range(func(key, value any) bool {
 		binding := value.(*RegisteredFunction).RawBindings[0]
 		if binding.EventHubBinding.Cardinality != "many" {
 			t.Errorf("expected cardinality %q, got %q", "many", binding.EventHubBinding.Cardinality)
+		}
+		return true
+	})
+}
+
+func TestServiceBusTopic_BatchHandlerDefaultsToMany(t *testing.T) {
+	app := FunctionApp()
+	handler := ServiceBusBatchHandler(func(ctx context.Context, messages []bindings.ServiceBusMessage) error { return nil })
+
+	app.ServiceBusTopicBatch("serviceBusTopicBatch", handler)
+
+	app.GetRegisteredFunctions().Range(func(key, value any) bool {
+		binding := value.(*RegisteredFunction).RawBindings[0]
+		if binding.ServiceBusBinding.Cardinality != "many" {
+			t.Errorf("expected cardinality %q, got %q", "many", binding.ServiceBusBinding.Cardinality)
 		}
 		return true
 	})

--- a/sdk/app_test.go
+++ b/sdk/app_test.go
@@ -836,7 +836,7 @@ func TestServiceBusQueue_WithIsSessionsEnabled(t *testing.T) {
 
 func TestServiceBusQueue_WithCardinality(t *testing.T) {
 	app := FunctionApp()
-	handler := ServiceBusHandler(func(ctx context.Context, msg bindings.ServiceBusMessage) error { return nil })
+	handler := ServiceBusBatchHandler(func(ctx context.Context, msg []bindings.ServiceBusMessage) error { return nil })
 
 	app.ServiceBusQueue("sbCard", handler,
 		WithQueueName("card-queue"),
@@ -854,6 +854,34 @@ func TestServiceBusQueue_WithCardinality(t *testing.T) {
 		}
 		return true
 	})
+}
+
+func TestEventHub_BatchHandlerDefaultsToMany(t *testing.T) {
+	app := FunctionApp()
+	handler := EventHubBatchHandler(func(ctx context.Context, events []bindings.EventHubMessage) error { return nil })
+
+	app.EventHub("eventHubBatch", handler)
+
+	app.GetRegisteredFunctions().Range(func(key, value any) bool {
+		binding := value.(*RegisteredFunction).RawBindings[0]
+		if binding.EventHubBinding.Cardinality != "many" {
+			t.Errorf("expected cardinality %q, got %q", "many", binding.EventHubBinding.Cardinality)
+		}
+		return true
+	})
+}
+
+func TestWithCardinality_PanicsOnHandlerMismatch(t *testing.T) {
+	app := FunctionApp()
+	handler := ServiceBusHandler(func(ctx context.Context, msg bindings.ServiceBusMessage) error { return nil })
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected cardinality and handler mismatch to panic")
+		}
+	}()
+
+	app.ServiceBusQueue("sbMismatch", handler, WithCardinality("many"))
 }
 
 // --- Blob panic tests ---

--- a/sdk/bindings/cosmos.go
+++ b/sdk/bindings/cosmos.go
@@ -36,7 +36,7 @@ type CosmosDocument struct {
 	Self        string          `json:"_self"`
 	Etag        string          `json:"_etag"`
 	Attachments string          `json:"_attachments"`
-	Timestamp   string          `json:"_ts"`
+	Timestamp   int64           `json:"_ts"`
 	Lsn         int             `json:"_lsn"`
 }
 

--- a/sdk/bindings/cosmos_test.go
+++ b/sdk/bindings/cosmos_test.go
@@ -92,12 +92,14 @@ func TestCosmosDBBinding_JSON_EmitsCreateLeaseContainerWhenTrue(t *testing.T) {
 	}
 }
 
+// TestCosmosDocument_JSON verifies that the document ID, body, timestamp, and LSN survive a JSON round trip.
 func TestCosmosDocument_JSON(t *testing.T) {
 	doc := CosmosDocument{
 		ID:        "doc-123",
 		Data:      json.RawMessage(`{"key":"value"}`),
 		Etag:      "etag-1",
-		Timestamp: "1234567890",
+		Timestamp: 1234567890,
+		Lsn:       5,
 	}
 
 	data, err := json.Marshal(doc)
@@ -115,6 +117,12 @@ func TestCosmosDocument_JSON(t *testing.T) {
 	}
 	if string(decoded.Data) != `{"key":"value"}` {
 		t.Errorf("expected data %q, got %q", `{"key":"value"}`, string(decoded.Data))
+	}
+	if decoded.Timestamp != 1234567890 {
+		t.Errorf("expected timestamp %d, got %d", int64(1234567890), decoded.Timestamp)
+	}
+	if decoded.Lsn != 5 {
+		t.Errorf("expected lsn 5, got %d", decoded.Lsn)
 	}
 }
 

--- a/sdk/bindings/eventhub.go
+++ b/sdk/bindings/eventhub.go
@@ -11,6 +11,7 @@ type EventHubBinding struct {
 	Connection    string `json:"connection"`
 	ConsumerGroup string `json:"consumerGroup,omitempty"`
 	Cardinality   string `json:"cardinality,omitempty"`
+	DataType      string `json:"dataType"`
 }
 
 // EventHubMessage represents a message received from an Azure Event Hub.
@@ -18,7 +19,7 @@ type EventHubBinding struct {
 // Other fields (SequenceNumber, Offset, etc.) are also populated from
 // trigger metadata using case-insensitive matching on their json tags.
 type EventHubMessage struct {
-	Body             json.RawMessage `json:"body"`
+	Body             json.RawMessage `json:"body" azfunc:"data"`
 	EnqueuedTimeUtc  string          `json:"enqueuedTimeUtc"`
 	SequenceNumber   int64           `json:"sequenceNumber"`
 	Offset           string          `json:"offset"`
@@ -50,6 +51,7 @@ func (e *EventHubTrigger) ToBinding() Binding {
 			Connection:    e.Connection,
 			ConsumerGroup: e.ConsumerGroup,
 			Cardinality:   e.Cardinality,
+			DataType:      "binary", // Preserve event bodies as bytes for both single events and batches.
 		},
 	}
 }

--- a/sdk/bindings/eventhub.go
+++ b/sdk/bindings/eventhub.go
@@ -15,7 +15,7 @@ type EventHubBinding struct {
 }
 
 // EventHubMessage represents a message received from an Azure Event Hub.
-// The Body field is populated from the "body" key in trigger metadata.
+// The Body field is populated from the raw trigger input.
 // Other fields (SequenceNumber, Offset, etc.) are also populated from
 // trigger metadata using case-insensitive matching on their json tags.
 type EventHubMessage struct {

--- a/sdk/bindings/eventhub_test.go
+++ b/sdk/bindings/eventhub_test.go
@@ -28,6 +28,9 @@ func TestEventHubTrigger_ToBinding(t *testing.T) {
 	if binding.EventHubBinding.EventHubName != "myeventhub" {
 		t.Errorf("expected eventHubName %q, got %q", "myeventhub", binding.EventHubBinding.EventHubName)
 	}
+	if binding.EventHubBinding.DataType != "binary" {
+		t.Errorf("expected dataType %q, got %q", "binary", binding.EventHubBinding.DataType)
+	}
 }
 
 func TestEventHubMessage_JSON(t *testing.T) {

--- a/sdk/bindings/queue.go
+++ b/sdk/bindings/queue.go
@@ -35,12 +35,11 @@ func (q *QueueStorageTrigger) ToBinding() Binding {
 }
 
 // QueueMessage represents a message received from Azure Storage Queue.
-// The Body field uses the special json tag "azfuncdata" which instructs the
-// worker's converter to populate this field from the raw trigger input data
-// rather than from trigger metadata. Other fields are populated from trigger
-// metadata using case-insensitive matching on their json tags.
+// The Body field is populated from the raw trigger input.
+// Other fields are populated from trigger metadata using case-insensitive
+// matching on their json tags.
 type QueueMessage struct {
-	Body            json.RawMessage `json:"azfuncdata"`
+	Body            json.RawMessage `json:"body" azfunc:"data"`
 	Id              string          `json:"id"`
 	PopReceipt      string          `json:"popReceipt"`
 	DequeueCount    int64           `json:"dequeueCount"`

--- a/sdk/bindings/queue_test.go
+++ b/sdk/bindings/queue_test.go
@@ -102,4 +102,14 @@ func TestQueueMessage_JSON(t *testing.T) {
 	if decoded.InsertionTime != "2026-06-22T18:57:34Z" {
 		t.Errorf("expected insertionTime %q, got %q", "2026-06-22T18:57:34Z", decoded.InsertionTime)
 	}
+	var encoded map[string]json.RawMessage
+	if err := json.Unmarshal(data, &encoded); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := encoded["body"]; !ok {
+		t.Error("expected body JSON property")
+	}
+	if _, ok := encoded["azfuncdata"]; ok {
+		t.Error("did not expect legacy azfuncdata JSON property")
+	}
 }

--- a/sdk/bindings/servicebus.go
+++ b/sdk/bindings/servicebus.go
@@ -17,12 +17,11 @@ type ServiceBusBinding struct {
 }
 
 // ServiceBusMessage represents a message received from Azure Service Bus.
-// The Body field uses the special json tag "azfuncdata" which instructs the
-// worker's converter to populate this field from the raw trigger input data
-// rather than from trigger metadata. Other fields are populated from trigger
-// metadata using case-insensitive matching on their json tags.
+// The Body field is populated from the raw trigger input.
+// Other fields are populated from trigger metadata using case-insensitive
+// matching on their json tags.
 type ServiceBusMessage struct {
-	Body                    json.RawMessage        `json:"azfuncdata"`
+	Body                    json.RawMessage        `json:"body" azfunc:"data"`
 	ContentType             string                 `json:"contentType"`
 	CorrelationId           string                 `json:"correlationId"`
 	DeliveryCount           int                    `json:"deliveryCount"`

--- a/sdk/bindings/servicebus.go
+++ b/sdk/bindings/servicebus.go
@@ -13,6 +13,7 @@ type ServiceBusBinding struct {
 	Connection        string `json:"connection"`
 	IsSessionsEnabled bool   `json:"isSessionsEnabled,omitempty"`
 	Cardinality       string `json:"cardinality,omitempty"`
+	DataType          string `json:"dataType"`
 }
 
 // ServiceBusMessage represents a message received from Azure Service Bus.
@@ -67,6 +68,7 @@ func (s *ServiceBusQueueTrigger) ToBinding() Binding {
 			Connection:        s.Connection,
 			IsSessionsEnabled: s.IsSessionsEnabled,
 			Cardinality:       s.Cardinality,
+			DataType:          "binary", // Preserve message bodies as bytes for both single messages and batches.
 		},
 	}
 }
@@ -96,6 +98,7 @@ func (s *ServiceBusTopicTrigger) ToBinding() Binding {
 			Connection:        s.Connection,
 			IsSessionsEnabled: s.IsSessionsEnabled,
 			Cardinality:       s.Cardinality,
+			DataType:          "binary", // Preserve message bodies as bytes for both single messages and batches.
 		},
 	}
 }

--- a/sdk/bindings/servicebus_test.go
+++ b/sdk/bindings/servicebus_test.go
@@ -27,6 +27,9 @@ func TestServiceBusQueueTrigger_ToBinding(t *testing.T) {
 	if binding.ServiceBusBinding.QueueName != "myqueue" {
 		t.Errorf("expected queueName %q, got %q", "myqueue", binding.ServiceBusBinding.QueueName)
 	}
+	if binding.ServiceBusBinding.DataType != "binary" {
+		t.Errorf("expected dataType %q, got %q", "binary", binding.ServiceBusBinding.DataType)
+	}
 }
 
 func TestServiceBusTopicTrigger_ToBinding(t *testing.T) {
@@ -48,6 +51,9 @@ func TestServiceBusTopicTrigger_ToBinding(t *testing.T) {
 	}
 	if binding.ServiceBusBinding.SubscriptionName != "mysub" {
 		t.Errorf("expected subscriptionName %q, got %q", "mysub", binding.ServiceBusBinding.SubscriptionName)
+	}
+	if binding.ServiceBusBinding.DataType != "binary" {
+		t.Errorf("expected dataType %q, got %q", "binary", binding.ServiceBusBinding.DataType)
 	}
 }
 

--- a/sdk/bindings/servicebus_test.go
+++ b/sdk/bindings/servicebus_test.go
@@ -81,4 +81,14 @@ func TestServiceBusMessage_JSON(t *testing.T) {
 	if decoded.LockToken != "token-abc" {
 		t.Errorf("expected lockToken %q, got %q", "token-abc", decoded.LockToken)
 	}
+	var encoded map[string]json.RawMessage
+	if err := json.Unmarshal(data, &encoded); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := encoded["body"]; !ok {
+		t.Error("expected body JSON property")
+	}
+	if _, ok := encoded["azfuncdata"]; ok {
+		t.Error("did not expect legacy azfuncdata JSON property")
+	}
 }

--- a/sdk/handlers.go
+++ b/sdk/handlers.go
@@ -36,8 +36,15 @@ type TimerHandler = func(context.Context, bindings.TimerInfo) error
 // (both queue and topic triggers).
 type ServiceBusHandler = func(context.Context, bindings.ServiceBusMessage) error
 
+// ServiceBusBatchHandler is the handler type for batched Service Bus triggered
+// functions (both queue and topic triggers).
+type ServiceBusBatchHandler = func(context.Context, []bindings.ServiceBusMessage) error
+
 // EventHubHandler is the handler type for Event Hub triggered functions.
 type EventHubHandler = func(context.Context, bindings.EventHubMessage) error
+
+// EventHubBatchHandler is the handler type for batched Event Hub triggered functions.
+type EventHubBatchHandler = func(context.Context, []bindings.EventHubMessage) error
 
 // CosmosDBHandler is the handler type for CosmosDB triggered functions.
 type CosmosDBHandler = func(context.Context, []bindings.CosmosDocument) error

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -2,7 +2,6 @@ package sdk
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -344,18 +343,22 @@ func WithCardinality(cardinality string) Option {
 		}
 		expected := ""
 		if b.EventHubBinding != nil {
-			expected = validateMessageHandler("EventHub", rf.Func, reflect.TypeOf(bindings.EventHubMessage{}))
-			b.EventHubBinding.Cardinality = cardinality
+			expected = b.EventHubBinding.Cardinality
 		}
 		if b.ServiceBusBinding != nil {
-			expected = validateMessageHandler("ServiceBus", rf.Func, reflect.TypeOf(bindings.ServiceBusMessage{}))
-			b.ServiceBusBinding.Cardinality = cardinality
+			expected = b.ServiceBusBinding.Cardinality
 		}
 		if expected != "" && cardinality != expected {
 			handlerTypes := map[string]string{"one": "single-message", "many": "batch"}
 			panic(fmt.Sprintf(
 				"cardinality %q does not match the registered %s handler; use cardinality %q or register a %s handler",
 				cardinality, handlerTypes[expected], expected, handlerTypes[cardinality]))
+		}
+		if b.EventHubBinding != nil {
+			b.EventHubBinding.Cardinality = cardinality
+		}
+		if b.ServiceBusBinding != nil {
+			b.ServiceBusBinding.Cardinality = cardinality
 		}
 	}
 }

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -1,6 +1,8 @@
 package sdk
 
 import (
+	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -327,18 +329,33 @@ func WithConnection(connection string) Option {
 }
 
 // WithCardinality sets the trigger cardinality ("one" or "many").
-// Works with EventHub and ServiceBus triggers.
+// The value must match the registered EventHub or ServiceBus handler shape.
 func WithCardinality(cardinality string) Option {
 	return func(rf *RegisteredFunction) {
 		b := rf.triggerBinding()
 		if b == nil {
 			return
 		}
+		if b.EventHubBinding == nil && b.ServiceBusBinding == nil {
+			return
+		}
+		if cardinality != "one" && cardinality != "many" {
+			panic(fmt.Sprintf("cardinality must be %q or %q, got %q", "one", "many", cardinality))
+		}
+		expected := ""
 		if b.EventHubBinding != nil {
+			expected = validateMessageHandler("EventHub", rf.Func, reflect.TypeOf(bindings.EventHubMessage{}))
 			b.EventHubBinding.Cardinality = cardinality
 		}
 		if b.ServiceBusBinding != nil {
+			expected = validateMessageHandler("ServiceBus", rf.Func, reflect.TypeOf(bindings.ServiceBusMessage{}))
 			b.ServiceBusBinding.Cardinality = cardinality
+		}
+		if expected != "" && cardinality != expected {
+			handlerTypes := map[string]string{"one": "single-message", "many": "batch"}
+			panic(fmt.Sprintf(
+				"cardinality %q does not match the registered %s handler; use cardinality %q or register a %s handler",
+				cardinality, handlerTypes[expected], expected, handlerTypes[cardinality]))
 		}
 	}
 }

--- a/tests/emulators/eventhub-emulator-config.json
+++ b/tests/emulators/eventhub-emulator-config.json
@@ -18,6 +18,13 @@
             "ConsumerGroups": [
               { "Name": "watchtower-test" }
             ]
+          },
+          {
+            "Name": "input-hub-batch",
+            "PartitionCount": "2",
+            "ConsumerGroups": [
+              { "Name": "watchtower-batch-test" }
+            ]
           }
         ]
       }

--- a/tests/emulators/servicebus-emulator-config.json
+++ b/tests/emulators/servicebus-emulator-config.json
@@ -14,6 +14,13 @@
             "Subscriptions": [
               { "Name": "processor", "Properties": {} }
             ]
+          },
+          {
+            "Name": "orders-batch",
+            "Properties": {},
+            "Subscriptions": [
+              { "Name": "processor-batch", "Properties": {} }
+            ]
           }
         ]
       }

--- a/tests/emulators/servicebus-emulator-config.json
+++ b/tests/emulators/servicebus-emulator-config.json
@@ -4,7 +4,8 @@
       {
         "Name": "emulatorns1",
         "Queues": [
-          { "Name": "input-queue", "Properties": {} }
+          { "Name": "input-queue", "Properties": {} },
+          { "Name": "input-queue-batch", "Properties": {} }
         ],
         "Topics": [
           {

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -95,6 +95,11 @@ invocations to a standard `net/http` handler, and returns the handler's status
 and body to the client. `TestHttpTriggerGet` exercises that path with both GET
 and POST requests.
 
+Event Hubs, Service Bus, and Cosmos DB scenarios are also available as explicit
+tests when the full emulator stack is started manually. Event Hubs and Service
+Bus queue coverage includes separate single-message and batch-delivery tests;
+the batch tests verify payloads and per-message metadata alignment.
+
 Run it from the integration-test module:
 
 ```bash
@@ -229,8 +234,8 @@ versions deliberately and validate the affected tests after each update.
 
 The following are planned but not implemented in this milestone:
 
-- **Additional trigger scenarios**: Timer, Blob Storage, Queue Storage, Event
-  Grid, Event Hubs, Cosmos DB, Service Bus, and SQL trigger tests.
+- **Runner coverage for additional trigger scenarios**: Timer, Blob Storage,
+  Queue Storage, Event Grid, Event Hubs, Cosmos DB, Service Bus, and SQL.
 - **Additional emulator profiles**: Event Hubs, Cosmos DB, Service Bus, and SQL
   Server containers with their own readiness checks and lifecycle management.
 - **JUnit output**: `go-test.xml` for Azure DevOps test result publishing.

--- a/tests/integration/cosmosdb_test.go
+++ b/tests/integration/cosmosdb_test.go
@@ -85,10 +85,10 @@ func TestCosmosDBTriggerFires(t *testing.T) {
 	requireCosmosDB(t)
 	ensureCosmosContainers(t)
 
-	proc := StartFuncHost(t, "cosmosDBTrigger", 7208, cosmosEnv, 40*time.Second)
+	host := startSampleHost(t, "cosmosDBTrigger", cosmosEnv, 40*time.Second)
 
 	// Wait for the change feed listener to acquire leases
-	proc.AssertLogContains("Started the listener", 60*time.Second)
+	assertHostLogContains(t, host, "Started the listener", 60*time.Second)
 
 	// Insert a document
 	cred, err := azcosmos.NewKeyCredential(cosmosKey)
@@ -119,6 +119,7 @@ func TestCosmosDBTriggerFires(t *testing.T) {
 	}
 
 	// Cosmos change feed can take 10-30s to detect changes
-	proc.AssertLogContains("Executing 'Functions.docs'", 45*time.Second)
-	proc.AssertLogContains("Succeeded", 10*time.Second)
+	assertHostLogContains(t, host, "Executing 'Functions.docs'", 45*time.Second)
+	assertHostLogContains(t, host, docID, 10*time.Second)
+	assertHostLogContains(t, host, "Executed 'Functions.docs' (Succeeded", 10*time.Second)
 }

--- a/tests/integration/eventhub_test.go
+++ b/tests/integration/eventhub_test.go
@@ -48,8 +48,7 @@ func TestEventHubTriggerMany(t *testing.T) {
 
 	assertHostLogContains(t, host, "batch_size=2", 5*time.Second)
 	for _, body := range bodies {
-		assertHostLogContains(t, host, body, 5*time.Second)
-		assertHostLogContains(t, host, "test_id="+body, 5*time.Second)
+		assertHostLogContains(t, host, "alignment_key="+body+"|"+body, 5*time.Second)
 	}
 	assertHostLogContains(t, host, "Executed 'Functions.eventHubBatchTrigger' (Succeeded", 5*time.Second)
 }

--- a/tests/integration/eventhub_test.go
+++ b/tests/integration/eventhub_test.go
@@ -3,10 +3,13 @@ package integration
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
+	"github.com/azure/azure-functions-golang-worker/tests/integration/internal/testhost"
 )
 
 const ehConnStr = "Endpoint=sb://127.0.0.2;" +
@@ -22,23 +25,54 @@ var eventHubEnv = map[string]string{
 func TestEventHubTriggerFires(t *testing.T) {
 	requireAzurite(t)
 	requireEventHub(t)
-	proc := StartFuncHost(t, "eventHubTrigger", 7207, eventHubEnv, 40*time.Second)
+	host := startSampleHost(t, "eventHubTrigger", eventHubEnv, 40*time.Second)
+	body := fmt.Sprintf("single-eventhub-%d", time.Now().UnixNano())
+	sendEventHubEventsUntilHandled(t, host, "input-hub", "eventhub trigger executed", body)
 
-	// Send events repeatedly — the listener may not be ready for the first few.
-	// The EH emulator's partition claim process is slow and unpredictable.
+	assertHostLogContains(t, host, body, 5*time.Second)
+	assertHostLogContains(t, host, "test_id="+body, 5*time.Second)
+	assertHostLogContains(t, host, "Executed 'Functions.eventHubTrigger' (Succeeded", 5*time.Second)
+}
+
+func TestEventHubTriggerMany(t *testing.T) {
+	requireAzurite(t)
+	requireEventHub(t)
+	host := startSampleHost(t, "eventHubTrigger", eventHubEnv, 40*time.Second)
+
+	runID := time.Now().UnixNano()
+	bodies := []string{
+		fmt.Sprintf("batch-eventhub-%d-1", runID),
+		fmt.Sprintf("batch-eventhub-%d-2", runID),
+	}
+	sendEventHubEventsUntilHandled(t, host, "input-hub-batch", "eventhub batch trigger executed", bodies...)
+
+	assertHostLogContains(t, host, "batch_size=2", 5*time.Second)
+	for _, body := range bodies {
+		assertHostLogContains(t, host, body, 5*time.Second)
+		assertHostLogContains(t, host, "test_id="+body, 5*time.Second)
+	}
+	assertHostLogContains(t, host, "Executed 'Functions.eventHubBatchTrigger' (Succeeded", 5*time.Second)
+}
+
+func sendEventHubEventsUntilHandled(t *testing.T, host testhost.Host, hub, handledPattern string, bodies ...string) {
+	t.Helper()
 	ctx := context.Background()
 	deadline := time.Now().Add(120 * time.Second)
 	attempt := 0
+	partitionID := "0"
 
+sendAttempts:
 	for time.Now().Before(deadline) {
 		attempt++
 
-		producer, err := azeventhubs.NewProducerClientFromConnectionString(ehConnStr, "input-hub", nil)
+		producer, err := azeventhubs.NewProducerClientFromConnectionString(ehConnStr, hub, nil)
 		if err != nil {
 			t.Fatalf("failed to create eventhub producer: %v", err)
 		}
 
-		batch, err := producer.NewEventDataBatch(ctx, nil)
+		batch, err := producer.NewEventDataBatch(ctx, &azeventhubs.EventDataBatchOptions{
+			PartitionID: &partitionID,
+		})
 		if err != nil {
 			producer.Close(ctx)
 			t.Logf("attempt %d: failed to create batch: %v", attempt, err)
@@ -46,14 +80,16 @@ func TestEventHubTriggerFires(t *testing.T) {
 			continue
 		}
 
-		err = batch.AddEventData(&azeventhubs.EventData{
-			Body: []byte(fmt.Sprintf("EH integration test event #%d", attempt)),
-		}, nil)
-		if err != nil {
-			producer.Close(ctx)
-			t.Logf("attempt %d: failed to add event: %v", attempt, err)
-			time.Sleep(10 * time.Second)
-			continue
+		for _, body := range bodies {
+			if err = batch.AddEventData(&azeventhubs.EventData{
+				Body:       []byte(body),
+				Properties: map[string]any{"testID": body},
+			}, nil); err != nil {
+				producer.Close(ctx)
+				t.Logf("attempt %d: failed to add event: %v", attempt, err)
+				time.Sleep(10 * time.Second)
+				continue sendAttempts
+			}
 		}
 
 		err = producer.SendEventDataBatch(ctx, batch, nil)
@@ -64,15 +100,13 @@ func TestEventHubTriggerFires(t *testing.T) {
 			continue
 		}
 
-		// Check if trigger already fired
-		log := proc.ReadLog()
-		if contains(log, "EventHub Trigger Executed") {
-			break
+		if hostLogContains(host, handledPattern, 10*time.Second) {
+			return
 		}
-
-		time.Sleep(10 * time.Second)
+		log, readErr := os.ReadFile(host.LogPath())
+		if readErr == nil && strings.Contains(string(log), "Exception binding parameter") {
+			t.Fatalf("event hub invocation failed during host binding:\n%s", string(log))
+		}
 	}
-
-	proc.AssertLogContains("eventhub trigger executed", 5*time.Second)
-	proc.AssertLogContains("Succeeded", 5*time.Second)
+	t.Fatalf("event hub handler log %q not observed before timeout", handledPattern)
 }

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/azure/azure-functions-golang-worker/tests/integration/internal/testhost"
 )
 
 // repoRoot returns the absolute path to the repository root.
@@ -89,6 +90,45 @@ func cleanAzuriteCheckpoints(t *testing.T) {
 	for _, name := range []string{"azure-webjobs-hosts", "azure-webjobs-eventhub"} {
 		_, _ = client.DeleteContainer(ctx, name, nil)
 	}
+}
+
+func startSampleHost(t *testing.T, sampleName string, env map[string]string, initTimeout time.Duration) testhost.Host {
+	t.Helper()
+	cleanAzuriteCheckpoints(t)
+
+	host, err := testhost.Start(context.Background(), testhost.Config{
+		SampleDir:   filepath.Join(samplesDir(), sampleName),
+		FuncExe:     funcExe(),
+		Environment: env,
+		ArtifactDir: filepath.Join("artifacts", t.Name()),
+		InitTimeout: initTimeout,
+	})
+	if err != nil {
+		t.Fatalf("start %s function host: %v", sampleName, err)
+	}
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := host.Stop(stopCtx); err != nil {
+			t.Errorf("stop %s function host: %v", sampleName, err)
+		}
+	})
+	return host
+}
+
+func assertHostLogContains(t *testing.T, host testhost.Host, pattern string, timeout time.Duration) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := host.WaitForLog(ctx, pattern); err != nil {
+		t.Fatalf("wait for host log pattern %q: %v", pattern, err)
+	}
+}
+
+func hostLogContains(host testhost.Host, pattern string, timeout time.Duration) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return host.WaitForLog(ctx, pattern) == nil
 }
 
 // FuncHostProcess manages a func.exe process for a sample directory.

--- a/tests/integration/servicebus_queue_test.go
+++ b/tests/integration/servicebus_queue_test.go
@@ -48,9 +48,7 @@ func TestServiceBusQueueTriggerMany(t *testing.T) {
 	assertHostLogContains(t, host, "servicebus queue batch trigger executed", 20*time.Second)
 	assertHostLogContains(t, host, "batch_size=2", 5*time.Second)
 	for _, body := range bodies {
-		assertHostLogContains(t, host, body, 5*time.Second)
-		assertHostLogContains(t, host, "message_id="+body, 5*time.Second)
-		assertHostLogContains(t, host, "test_id="+body, 5*time.Second)
+		assertHostLogContains(t, host, "alignment_key="+body+"|"+body+"|"+body, 5*time.Second)
 	}
 	assertHostLogContains(t, host, "Executed 'Functions.queueBatchFunc' (Succeeded", 5*time.Second)
 }

--- a/tests/integration/servicebus_queue_test.go
+++ b/tests/integration/servicebus_queue_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -21,28 +22,67 @@ var serviceBusQueueEnv = map[string]string{
 func TestServiceBusQueueTriggerFires(t *testing.T) {
 	requireAzurite(t)
 	requireServiceBus(t)
-	proc := StartFuncHost(t, "serviceBusQueueTrigger", 7205, serviceBusQueueEnv, 30*time.Second)
+	host := startSampleHost(t, "serviceBusQueueTrigger", serviceBusQueueEnv, 30*time.Second)
 
-	// Send a message to the queue
+	body := fmt.Sprintf("single-servicebus-%d", time.Now().UnixNano())
+	sendServiceBusMessages(t, "input-queue", body)
+
+	assertHostLogContains(t, host, "servicebus queue trigger executed", 15*time.Second)
+	assertHostLogContains(t, host, body, 5*time.Second)
+	assertHostLogContains(t, host, "test_id="+body, 5*time.Second)
+	assertHostLogContains(t, host, "Executed 'Functions.queueFunc' (Succeeded", 5*time.Second)
+}
+
+func TestServiceBusQueueTriggerMany(t *testing.T) {
+	requireAzurite(t)
+	requireServiceBus(t)
+	host := startSampleHost(t, "serviceBusQueueTrigger", serviceBusQueueEnv, 30*time.Second)
+
+	runID := time.Now().UnixNano()
+	bodies := []string{
+		fmt.Sprintf("batch-servicebus-%d-1", runID),
+		fmt.Sprintf("batch-servicebus-%d-2", runID),
+	}
+	sendServiceBusMessages(t, "input-queue-batch", bodies...)
+
+	assertHostLogContains(t, host, "servicebus queue batch trigger executed", 20*time.Second)
+	assertHostLogContains(t, host, "batch_size=2", 5*time.Second)
+	for _, body := range bodies {
+		assertHostLogContains(t, host, body, 5*time.Second)
+		assertHostLogContains(t, host, "message_id="+body, 5*time.Second)
+		assertHostLogContains(t, host, "test_id="+body, 5*time.Second)
+	}
+	assertHostLogContains(t, host, "Executed 'Functions.queueBatchFunc' (Succeeded", 5*time.Second)
+}
+
+func sendServiceBusMessages(t *testing.T, entity string, bodies ...string) {
+	t.Helper()
 	client, err := azservicebus.NewClientFromConnectionString(sbConnStr, nil)
 	if err != nil {
 		t.Fatalf("failed to create service bus client: %v", err)
 	}
 	defer client.Close(context.Background())
 
-	sender, err := client.NewSender("input-queue", nil)
+	sender, err := client.NewSender(entity, nil)
 	if err != nil {
 		t.Fatalf("failed to create sender: %v", err)
 	}
 	defer sender.Close(context.Background())
 
-	err = sender.SendMessage(context.Background(), &azservicebus.Message{
-		Body: []byte("Hello from SB queue integration test!"),
-	}, nil)
+	batch, err := sender.NewMessageBatch(context.Background(), nil)
 	if err != nil {
-		t.Fatalf("failed to send message: %v", err)
+		t.Fatalf("failed to create message batch: %v", err)
 	}
-
-	proc.AssertLogContains("servicebus queue trigger executed", 15*time.Second)
-	proc.AssertLogContains("Succeeded", 5*time.Second)
+	for _, body := range bodies {
+		if err := batch.AddMessage(&azservicebus.Message{
+			Body:                  []byte(body),
+			MessageID:             &body,
+			ApplicationProperties: map[string]any{"testID": body},
+		}, nil); err != nil {
+			t.Fatalf("failed to add message to batch: %v", err)
+		}
+	}
+	if err := sender.SendMessageBatch(context.Background(), batch, nil); err != nil {
+		t.Fatalf("failed to send messages: %v", err)
+	}
 }

--- a/tests/integration/servicebus_topic_test.go
+++ b/tests/integration/servicebus_topic_test.go
@@ -1,11 +1,9 @@
 package integration
 
 import (
-	"context"
+	"fmt"
 	"testing"
 	"time"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
 )
 
 var serviceBusTopicEnv = map[string]string{
@@ -16,28 +14,13 @@ var serviceBusTopicEnv = map[string]string{
 func TestServiceBusTopicTriggerFires(t *testing.T) {
 	requireAzurite(t)
 	requireServiceBus(t)
-	proc := StartFuncHost(t, "serviceBusTopicTrigger", 7206, serviceBusTopicEnv, 30*time.Second)
+	host := startSampleHost(t, "serviceBusTopicTrigger", serviceBusTopicEnv, 30*time.Second)
 
-	// Send a message to the topic
-	client, err := azservicebus.NewClientFromConnectionString(sbConnStr, nil)
-	if err != nil {
-		t.Fatalf("failed to create service bus client: %v", err)
-	}
-	defer client.Close(context.Background())
+	body := fmt.Sprintf("single-servicebus-topic-%d", time.Now().UnixNano())
+	sendServiceBusMessages(t, "orders", body)
 
-	sender, err := client.NewSender("orders", nil)
-	if err != nil {
-		t.Fatalf("failed to create sender: %v", err)
-	}
-	defer sender.Close(context.Background())
-
-	err = sender.SendMessage(context.Background(), &azservicebus.Message{
-		Body: []byte("Order #99 from topic integration test"),
-	}, nil)
-	if err != nil {
-		t.Fatalf("failed to send message: %v", err)
-	}
-
-	proc.AssertLogContains("servicebus topic trigger executed", 15*time.Second)
-	proc.AssertLogContains("Succeeded", 5*time.Second)
+	assertHostLogContains(t, host, "servicebus topic trigger executed", 15*time.Second)
+	assertHostLogContains(t, host, body, 5*time.Second)
+	assertHostLogContains(t, host, "test_id="+body, 5*time.Second)
+	assertHostLogContains(t, host, "Executed 'Functions.topicFunc' (Succeeded", 5*time.Second)
 }

--- a/tests/integration/servicebus_topic_test.go
+++ b/tests/integration/servicebus_topic_test.go
@@ -24,3 +24,23 @@ func TestServiceBusTopicTriggerFires(t *testing.T) {
 	assertHostLogContains(t, host, "test_id="+body, 5*time.Second)
 	assertHostLogContains(t, host, "Executed 'Functions.topicFunc' (Succeeded", 5*time.Second)
 }
+
+func TestServiceBusTopicTriggerMany(t *testing.T) {
+	requireAzurite(t)
+	requireServiceBus(t)
+	host := startSampleHost(t, "serviceBusTopicTrigger", serviceBusTopicEnv, 30*time.Second)
+
+	runID := time.Now().UnixNano()
+	bodies := []string{
+		fmt.Sprintf("batch-servicebus-topic-%d-1", runID),
+		fmt.Sprintf("batch-servicebus-topic-%d-2", runID),
+	}
+	sendServiceBusMessages(t, "orders-batch", bodies...)
+
+	assertHostLogContains(t, host, "servicebus topic batch trigger executed", 20*time.Second)
+	assertHostLogContains(t, host, "batch_size=2", 5*time.Second)
+	for _, body := range bodies {
+		assertHostLogContains(t, host, "alignment_key="+body+"|"+body+"|"+body, 5*time.Second)
+	}
+	assertHostLogContains(t, host, "Executed 'Functions.topicBatchFunc' (Succeeded", 5*time.Second)
+}

--- a/worker/converter.go
+++ b/worker/converter.go
@@ -84,6 +84,10 @@ func convertToTypeValue(pt reflect.Type, data *pb.TypedData, tm map[string]*pb.T
 	pv := reflect.New(t)
 	v := pv.Elem()
 
+	// Batch triggers arrive as a TypedData collection plus parallel metadata
+	// arrays. Decode each entry as its target struct instead of using the
+	// default slice decoder so empty payloads retain their position and each
+	// struct receives metadata from the same batch index.
 	if t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Struct {
 		if values, ok := typedDataCollectionValues(data); ok {
 			result := reflect.MakeSlice(t, len(values), len(values))

--- a/worker/converter.go
+++ b/worker/converter.go
@@ -58,11 +58,9 @@ func isAzFuncDataField(f reflect.StructField) bool {
 	return strings.EqualFold(tag, azFuncDataTag)
 }
 
-// hasAzFuncDataField reports whether the struct type t declares any field
-// tagged with azFuncDataTag. Structs that opt into this tag use a single
-// field to hold the raw input body while other fields are populated from
-// trigger metadata, and must NOT be decoded via whole-struct json.Unmarshal
-// of the body.
+// hasAzFuncDataField reports whether the struct type t declares a field that
+// receives raw trigger input. These structs must not be decoded via
+// whole-struct json.Unmarshal of the body.
 func hasAzFuncDataField(t reflect.Type) bool {
 	for i := 0; i < t.NumField(); i++ {
 		if isAzFuncDataField(t.Field(i)) {
@@ -92,10 +90,7 @@ func convertToTypeValue(pt reflect.Type, data *pb.TypedData, tm map[string]*pb.T
 		if values, ok := typedDataCollectionValues(data); ok {
 			result := reflect.MakeSlice(t, len(values), len(values))
 			for i, value := range values {
-				metadata, err := collectionMetadataAt(tm, i)
-				if err != nil {
-					return reflect.Value{}, err
-				}
+				metadata := collectionMetadataAt(tm, i)
 				element, err := convertToTypeValue(t.Elem(), value, metadata)
 				if err != nil {
 					return reflect.Value{}, fmt.Errorf("failed to decode collection element %d: %w", i, err)
@@ -114,7 +109,7 @@ func convertToTypeValue(pt reflect.Type, data *pb.TypedData, tm map[string]*pb.T
 	// not unmarshalled across the whole struct. Without this guard, a queue
 	// message with a JSON object body would silently produce a zero-valued
 	// QueueMessage — the unmarshal succeeds but matches no field tags, the
-	// fast path returns, and the per-field "azfuncdata" + metadata fallback
+	// fast path returns, and the per-field raw-data + metadata fallback
 	// below is never reached.
 	if t.Kind() == reflect.Struct && !hasAzFuncDataField(t) {
 		// Try direct JSON unmarshal from input data (TypedData_Json or TypedData_String_)
@@ -238,23 +233,27 @@ func typedDataCollectionValues(data *pb.TypedData) ([]*pb.TypedData, bool) {
 	return nil, false
 }
 
-func collectionMetadataAt(metadata map[string]*pb.TypedData, index int) (map[string]*pb.TypedData, error) {
+func collectionMetadataAt(metadata map[string]*pb.TypedData, index int) map[string]*pb.TypedData {
 	result := make(map[string]*pb.TypedData, len(metadata))
 	for name, value := range metadata {
 		if !strings.HasSuffix(strings.ToLower(name), "array") {
 			result[name] = value
-			continue
-		}
-
-		element, ok, err := typedDataElementAt(value, index)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode trigger metadata %q: %w", name, err)
-		}
-		if ok {
-			result[name[:len(name)-len("Array")]] = element
 		}
 	}
-	return result, nil
+
+	// Apply per-message metadata after scalar metadata so an XArray entry
+	// deterministically overrides an X entry for the corresponding message.
+	for name, value := range metadata {
+		if !strings.HasSuffix(strings.ToLower(name), "array") {
+			continue
+		}
+		element, ok, err := typedDataElementAt(value, index)
+		if err != nil || !ok {
+			continue
+		}
+		result[name[:len(name)-len("Array")]] = element
+	}
+	return result
 }
 
 func typedDataElementAt(data *pb.TypedData, index int) (*pb.TypedData, bool, error) {

--- a/worker/converter.go
+++ b/worker/converter.go
@@ -41,15 +41,16 @@ func FromProto(req *pb.InvocationRequest, fields map[string]*funcField, args []r
 	return nil
 }
 
-// azFuncDataTag is the special json struct-field tag used by SDK binding
-// types (e.g. QueueMessage, ServiceBusMessage) to mark the single field
-// that should receive the raw trigger input body. All other fields on
-// such a struct are populated from trigger metadata, looked up by name.
+// azFuncDataTag is the legacy json struct-field tag used by SDK binding
+// types to mark the field that receives the raw trigger input body. New
+// bindings can preserve their public JSON name with the azfunc:"data" tag.
 const azFuncDataTag = "azfuncdata"
 
-// isAzFuncDataField reports whether field f opts into azFuncDataTag.
-// Matching is case-insensitive and tolerates options like ",omitempty".
+// isAzFuncDataField reports whether field f opts into raw trigger input data.
 func isAzFuncDataField(f reflect.StructField) bool {
+	if strings.EqualFold(f.Tag.Get("azfunc"), "data") {
+		return true
+	}
 	tag := f.Tag.Get("json")
 	if idx := strings.Index(tag, ","); idx != -1 {
 		tag = tag[:idx]
@@ -82,6 +83,24 @@ func convertToTypeValue(pt reflect.Type, data *pb.TypedData, tm map[string]*pb.T
 
 	pv := reflect.New(t)
 	v := pv.Elem()
+
+	if t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Struct {
+		if values, ok := typedDataCollectionValues(data); ok {
+			result := reflect.MakeSlice(t, len(values), len(values))
+			for i, value := range values {
+				metadata, err := collectionMetadataAt(tm, i)
+				if err != nil {
+					return reflect.Value{}, err
+				}
+				element, err := convertToTypeValue(t.Elem(), value, metadata)
+				if err != nil {
+					return reflect.Value{}, fmt.Errorf("failed to decode collection element %d: %w", i, err)
+				}
+				result.Index(i).Set(element)
+			}
+			return result, nil
+		}
+	}
 
 	// If struct, try JSON decoding first, then fall back to TriggerMetadata field matching.
 	//
@@ -178,6 +197,81 @@ func convertToTypeValue(pt reflect.Type, data *pb.TypedData, tm map[string]*pb.T
 		return ptr, nil
 	}
 	return d, nil
+}
+
+func typedDataCollectionValues(data *pb.TypedData) ([]*pb.TypedData, bool) {
+	if data == nil {
+		return nil, false
+	}
+	if collection := data.GetCollectionBytes(); collection != nil {
+		values := make([]*pb.TypedData, len(collection.GetBytes()))
+		for i, value := range collection.GetBytes() {
+			values[i] = &pb.TypedData{Data: &pb.TypedData_Bytes{Bytes: value}}
+		}
+		return values, true
+	}
+	if collection := data.GetCollectionString(); collection != nil {
+		values := make([]*pb.TypedData, len(collection.GetString_()))
+		for i, value := range collection.GetString_() {
+			values[i] = &pb.TypedData{Data: &pb.TypedData_String_{String_: value}}
+		}
+		return values, true
+	}
+	if collection := data.GetCollectionDouble(); collection != nil {
+		values := make([]*pb.TypedData, len(collection.GetDouble()))
+		for i, value := range collection.GetDouble() {
+			values[i] = &pb.TypedData{Data: &pb.TypedData_Double{Double: value}}
+		}
+		return values, true
+	}
+	if collection := data.GetCollectionSint64(); collection != nil {
+		values := make([]*pb.TypedData, len(collection.GetSint64()))
+		for i, value := range collection.GetSint64() {
+			values[i] = &pb.TypedData{Data: &pb.TypedData_Int{Int: value}}
+		}
+		return values, true
+	}
+	return nil, false
+}
+
+func collectionMetadataAt(metadata map[string]*pb.TypedData, index int) (map[string]*pb.TypedData, error) {
+	result := make(map[string]*pb.TypedData, len(metadata))
+	for name, value := range metadata {
+		if !strings.HasSuffix(strings.ToLower(name), "array") {
+			result[name] = value
+			continue
+		}
+
+		element, ok, err := typedDataElementAt(value, index)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode trigger metadata %q: %w", name, err)
+		}
+		if ok {
+			result[name[:len(name)-len("Array")]] = element
+		}
+	}
+	return result, nil
+}
+
+func typedDataElementAt(data *pb.TypedData, index int) (*pb.TypedData, bool, error) {
+	if values, ok := typedDataCollectionValues(data); ok {
+		if index >= len(values) {
+			return nil, false, nil
+		}
+		return values[index], true, nil
+	}
+
+	if data == nil || data.GetJson() == "" {
+		return nil, false, nil
+	}
+	var values []json.RawMessage
+	if err := json.Unmarshal([]byte(data.GetJson()), &values); err != nil {
+		return nil, false, err
+	}
+	if index >= len(values) {
+		return nil, false, nil
+	}
+	return &pb.TypedData{Data: &pb.TypedData_Json{Json: string(values[index])}}, true, nil
 }
 
 // decodeProto converts a single TypedData value from the host into a Go

--- a/worker/converter_batch_test.go
+++ b/worker/converter_batch_test.go
@@ -63,6 +63,48 @@ func TestConvertToTypeValue_EventHubBatch(t *testing.T) {
 	}
 }
 
+func TestConvertToTypeValue_EventHubBatchPreservesEmptyEntryAlignment(t *testing.T) {
+	data := &pb.TypedData{Data: &pb.TypedData_CollectionBytes{
+		CollectionBytes: &pb.CollectionBytes{Bytes: [][]byte{[]byte("first"), {}, []byte("third")}},
+	}}
+	metadata := map[string]*pb.TypedData{
+		"SequenceNumberArray": {
+			Data: &pb.TypedData_CollectionSint64{
+				CollectionSint64: &pb.CollectionSInt64{Sint64: []int64{10, 11, 12}},
+			},
+		},
+		"OffsetArray": {
+			Data: &pb.TypedData_CollectionString{
+				CollectionString: &pb.CollectionString{String_: []string{"100", "", "300"}},
+			},
+		},
+	}
+
+	value, err := convertToTypeValue(reflect.TypeOf([]bindings.EventHubMessage{}), data, metadata)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	events := value.Interface().([]bindings.EventHubMessage)
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+
+	expectedBodies := []string{"first", "", "third"}
+	expectedSequenceNumbers := []int64{10, 11, 12}
+	expectedOffsets := []string{"100", "", "300"}
+	for i, event := range events {
+		if string(event.Body) != expectedBodies[i] {
+			t.Errorf("event %d: expected body %q, got %q", i, expectedBodies[i], event.Body)
+		}
+		if event.SequenceNumber != expectedSequenceNumbers[i] {
+			t.Errorf("event %d: expected sequence number %d, got %d", i, expectedSequenceNumbers[i], event.SequenceNumber)
+		}
+		if event.Offset != expectedOffsets[i] {
+			t.Errorf("event %d: expected offset %q, got %q", i, expectedOffsets[i], event.Offset)
+		}
+	}
+}
+
 func TestConvertToTypeValue_ServiceBusBatch(t *testing.T) {
 	data := &pb.TypedData{Data: &pb.TypedData_CollectionString{
 		CollectionString: &pb.CollectionString{String_: []string{`"first"`, `"second"`}},

--- a/worker/converter_batch_test.go
+++ b/worker/converter_batch_test.go
@@ -143,3 +143,53 @@ func TestConvertToTypeValue_ServiceBusBatch(t *testing.T) {
 		t.Fatalf("unexpected second body %q: %v", messages[1].Body, err)
 	}
 }
+
+func TestConvertToTypeValue_BatchMetadataArrayOverridesScalar(t *testing.T) {
+	data := &pb.TypedData{Data: &pb.TypedData_CollectionBytes{
+		CollectionBytes: &pb.CollectionBytes{Bytes: [][]byte{[]byte("first"), []byte("second")}},
+	}}
+	metadata := map[string]*pb.TypedData{
+		"MessageId": {
+			Data: &pb.TypedData_String_{String_: "scalar-id"},
+		},
+		"MessageIdArray": {
+			Data: &pb.TypedData_CollectionString{
+				CollectionString: &pb.CollectionString{String_: []string{"id-1", "id-2"}},
+			},
+		},
+	}
+
+	value, err := convertToTypeValue(reflect.TypeOf([]bindings.ServiceBusMessage{}), data, metadata)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	messages := value.Interface().([]bindings.ServiceBusMessage)
+	if messages[0].MessageId != "id-1" || messages[1].MessageId != "id-2" {
+		t.Fatalf("expected per-message IDs to override scalar metadata, got %+v", messages)
+	}
+}
+
+func TestConvertToTypeValue_BatchSkipsMalformedArrayMetadata(t *testing.T) {
+	data := &pb.TypedData{Data: &pb.TypedData_CollectionBytes{
+		CollectionBytes: &pb.CollectionBytes{Bytes: [][]byte{[]byte("first"), []byte("second")}},
+	}}
+	metadata := map[string]*pb.TypedData{
+		"MessageIdArray": {
+			Data: &pb.TypedData_CollectionString{
+				CollectionString: &pb.CollectionString{String_: []string{"id-1", "id-2"}},
+			},
+		},
+		"SomeWeirdArray": {
+			Data: &pb.TypedData_Json{Json: `{"not":"an array"}`},
+		},
+	}
+
+	value, err := convertToTypeValue(reflect.TypeOf([]bindings.ServiceBusMessage{}), data, metadata)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	messages := value.Interface().([]bindings.ServiceBusMessage)
+	if len(messages) != 2 || messages[0].MessageId != "id-1" || messages[1].MessageId != "id-2" {
+		t.Fatalf("unexpected messages: %+v", messages)
+	}
+}

--- a/worker/converter_batch_test.go
+++ b/worker/converter_batch_test.go
@@ -1,0 +1,103 @@
+package worker
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/azure/azure-functions-golang-worker/sdk/bindings"
+	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
+)
+
+func TestConvertToTypeValue_CosmosBatch(t *testing.T) {
+	data := &pb.TypedData{Data: &pb.TypedData_String_{String_: `[
+		{"id":"doc-123","data":"hello","_ts":1785870475,"_lsn":5}
+	]`}}
+
+	value, err := convertToTypeValue(reflect.TypeOf([]bindings.CosmosDocument{}), data, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	documents := value.Interface().([]bindings.CosmosDocument)
+	if len(documents) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(documents))
+	}
+	if documents[0].Timestamp != 1785870475 {
+		t.Errorf("expected timestamp %d, got %d", int64(1785870475), documents[0].Timestamp)
+	}
+}
+
+func TestConvertToTypeValue_EventHubBatch(t *testing.T) {
+	data := &pb.TypedData{Data: &pb.TypedData_CollectionBytes{
+		CollectionBytes: &pb.CollectionBytes{Bytes: [][]byte{[]byte(`{"id":1}`), []byte(`{"id":2}`)}},
+	}}
+	metadata := map[string]*pb.TypedData{
+		"SequenceNumberArray": {
+			Data: &pb.TypedData_CollectionSint64{
+				CollectionSint64: &pb.CollectionSInt64{Sint64: []int64{10, 11}},
+			},
+		},
+		"OffsetArray": {
+			Data: &pb.TypedData_CollectionString{
+				CollectionString: &pb.CollectionString{String_: []string{"100", "200"}},
+			},
+		},
+		"PropertiesArray": {
+			Data: &pb.TypedData_Json{Json: `[{"source":"first"},{"source":"second"}]`},
+		},
+	}
+
+	value, err := convertToTypeValue(reflect.TypeOf([]bindings.EventHubMessage{}), data, metadata)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	events := value.Interface().([]bindings.EventHubMessage)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if string(events[0].Body) != `{"id":1}` || events[1].SequenceNumber != 11 || events[1].Offset != "200" {
+		t.Fatalf("unexpected events: %+v", events)
+	}
+	if events[0].Properties["source"] != "first" {
+		t.Fatalf("unexpected properties: %+v", events[0].Properties)
+	}
+}
+
+func TestConvertToTypeValue_ServiceBusBatch(t *testing.T) {
+	data := &pb.TypedData{Data: &pb.TypedData_CollectionString{
+		CollectionString: &pb.CollectionString{String_: []string{`"first"`, `"second"`}},
+	}}
+	metadata := map[string]*pb.TypedData{
+		"MessageIdArray": {
+			Data: &pb.TypedData_CollectionString{
+				CollectionString: &pb.CollectionString{String_: []string{"id-1", "id-2"}},
+			},
+		},
+		"DeliveryCountArray": {
+			Data: &pb.TypedData_Json{Json: `[1,2]`},
+		},
+		"ApplicationPropertiesArray": {
+			Data: &pb.TypedData_Json{Json: `[{"priority":"low"},{"priority":"high"}]`},
+		},
+	}
+
+	value, err := convertToTypeValue(reflect.TypeOf([]bindings.ServiceBusMessage{}), data, metadata)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	messages := value.Interface().([]bindings.ServiceBusMessage)
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(messages))
+	}
+	if string(messages[0].Body) != `"first"` || messages[1].MessageId != "id-2" || messages[1].DeliveryCount != 2 {
+		t.Fatalf("unexpected messages: %+v", messages)
+	}
+	if messages[1].ApplicationProperties["priority"] != "high" {
+		t.Fatalf("unexpected application properties: %+v", messages[1].ApplicationProperties)
+	}
+
+	var body string
+	if err := json.Unmarshal(messages[1].Body, &body); err != nil || body != "second" {
+		t.Fatalf("unexpected second body %q: %v", messages[1].Body, err)
+	}
+}

--- a/worker/dispatcher_test.go
+++ b/worker/dispatcher_test.go
@@ -104,6 +104,10 @@ func TestProcessRequestMessage_WorkerInit_PropagatesCapabilities(t *testing.T) {
 	if caps["AnotherFlag"] != "yes" {
 		t.Errorf("AnotherFlag = %q, want %q", caps["AnotherFlag"], "yes")
 	}
+	if caps["IncludeEmptyEntriesInMessagePayload"] != "true" {
+		t.Errorf("IncludeEmptyEntriesInMessagePayload = %q, want %q",
+			caps["IncludeEmptyEntriesInMessagePayload"], "true")
+	}
 }
 
 func TestProcessRequestMessage_FunctionsMetadata(t *testing.T) {

--- a/worker/handlers.go
+++ b/worker/handlers.go
@@ -30,13 +30,14 @@ func handleWorkerInitRequest(req *pb.WorkerInitRequest, requestId string, disp *
 	// host will then forward HTTP requests to that URL via YARP and skip the
 	// gRPC body for HTTP triggers, enabling true streaming.
 	capabilities := map[string]string{
-		"TypedDataCollection":               "true",
-		"WorkerStatus":                      "true",
-		"RpcHttpBodyOnly":                   "true",
-		"RawHttpBodyBytes":                  "true",
-		"RpcHttpTriggerMetadataRemoved":     "true",
-		"UseNullableValueDictionaryForHttp": "true",
-		"HandlesWorkerTerminateMessage":     "true",
+		"TypedDataCollection":                 "true",
+		"IncludeEmptyEntriesInMessagePayload": "true",
+		"WorkerStatus":                        "true",
+		"RpcHttpBodyOnly":                     "true",
+		"RawHttpBodyBytes":                    "true",
+		"RpcHttpTriggerMetadataRemoved":       "true",
+		"UseNullableValueDictionaryForHttp":   "true",
+		"HandlesWorkerTerminateMessage":       "true",
 	}
 
 	// Merge in capabilities advertised by the user app (e.g. middleware that

--- a/worker/handlers_batch_test.go
+++ b/worker/handlers_batch_test.go
@@ -1,0 +1,104 @@
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/azure/azure-functions-golang-worker/sdk"
+	"github.com/azure/azure-functions-golang-worker/sdk/bindings"
+	pb "github.com/azure/azure-functions-golang-worker/worker/proto"
+)
+
+func TestHandleInvocationRequest_EventHubBatch(t *testing.T) {
+	var got []bindings.EventHubMessage
+	app := newTestApp()
+	dispatcher := newTestDispatcher("req-eventhub-batch")
+	dispatcher.App = app
+	registered := app.EventHub("events", sdk.EventHubBatchHandler(
+		func(ctx context.Context, events []bindings.EventHubMessage) error {
+			got = events
+			return nil
+		},
+	))
+
+	handleFunctionLoadRequest(&pb.FunctionLoadRequest{FunctionId: registered.FuncId}, dispatcher, "req-eventhub-batch")
+	response, err := handleInvocationRequest(batchInvocationRequest(
+		registered.FuncId,
+		&pb.TypedData{Data: &pb.TypedData_CollectionBytes{
+			CollectionBytes: &pb.CollectionBytes{Bytes: [][]byte{[]byte("first"), []byte("second")}},
+		}},
+		map[string]*pb.TypedData{
+			"SequenceNumberArray": {
+				Data: &pb.TypedData_CollectionSint64{
+					CollectionSint64: &pb.CollectionSInt64{Sint64: []int64{1, 2}},
+				},
+			},
+		},
+	), dispatcher, "req-eventhub-batch")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	invocation := response.GetContent().(*pb.StreamingMessage_InvocationResponse).InvocationResponse
+	if invocation.Result.Status != pb.StatusResult_Success {
+		t.Fatalf("expected success, got %v", invocation.Result.Status)
+	}
+	if len(got) != 2 || string(got[1].Body) != "second" || got[1].SequenceNumber != 2 {
+		t.Fatalf("unexpected events: %+v", got)
+	}
+}
+
+func TestHandleInvocationRequest_ServiceBusBatch(t *testing.T) {
+	var got []bindings.ServiceBusMessage
+	app := newTestApp()
+	dispatcher := newTestDispatcher("req-servicebus-batch")
+	dispatcher.App = app
+	registered := app.ServiceBusQueue("messages", sdk.ServiceBusBatchHandler(
+		func(ctx context.Context, messages []bindings.ServiceBusMessage) error {
+			got = messages
+			return nil
+		},
+	))
+
+	handleFunctionLoadRequest(&pb.FunctionLoadRequest{FunctionId: registered.FuncId}, dispatcher, "req-servicebus-batch")
+	response, err := handleInvocationRequest(batchInvocationRequest(
+		registered.FuncId,
+		&pb.TypedData{Data: &pb.TypedData_CollectionString{
+			CollectionString: &pb.CollectionString{String_: []string{"first", "second"}},
+		}},
+		map[string]*pb.TypedData{
+			"MessageIdArray": {
+				Data: &pb.TypedData_CollectionString{
+					CollectionString: &pb.CollectionString{String_: []string{"id-1", "id-2"}},
+				},
+			},
+		},
+	), dispatcher, "req-servicebus-batch")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	invocation := response.GetContent().(*pb.StreamingMessage_InvocationResponse).InvocationResponse
+	if invocation.Result.Status != pb.StatusResult_Success {
+		t.Fatalf("expected success, got %v", invocation.Result.Status)
+	}
+	if len(got) != 2 || string(got[1].Body) != "second" || got[1].MessageId != "id-2" {
+		t.Fatalf("unexpected messages: %+v", got)
+	}
+}
+
+func batchInvocationRequest(functionID string, data *pb.TypedData, metadata map[string]*pb.TypedData) *pb.InvocationRequest {
+	return &pb.InvocationRequest{
+		FunctionId:      functionID,
+		InvocationId:    "inv-batch",
+		TriggerMetadata: metadata,
+		InputData: []*pb.ParameterBinding{
+			{
+				Name: "message",
+				RpcData: &pb.ParameterBinding_Data{
+					Data: data,
+				},
+			},
+		},
+	}
+}

--- a/worker/handlers_batch_test.go
+++ b/worker/handlers_batch_test.go
@@ -14,7 +14,7 @@ func TestHandleInvocationRequest_EventHubBatch(t *testing.T) {
 	app := newTestApp()
 	dispatcher := newTestDispatcher("req-eventhub-batch")
 	dispatcher.App = app
-	registered := app.EventHub("events", sdk.EventHubBatchHandler(
+	registered := app.EventHubBatch("events", sdk.EventHubBatchHandler(
 		func(ctx context.Context, events []bindings.EventHubMessage) error {
 			got = events
 			return nil
@@ -53,7 +53,7 @@ func TestHandleInvocationRequest_ServiceBusBatch(t *testing.T) {
 	app := newTestApp()
 	dispatcher := newTestDispatcher("req-servicebus-batch")
 	dispatcher.App = app
-	registered := app.ServiceBusQueue("messages", sdk.ServiceBusBatchHandler(
+	registered := app.ServiceBusQueueBatch("messages", sdk.ServiceBusBatchHandler(
 		func(ctx context.Context, messages []bindings.ServiceBusMessage) error {
 			got = messages
 			return nil


### PR DESCRIPTION
## Summary

- Add `EventHubBatch`, `ServiceBusQueueBatch`, and `ServiceBusTopicBatch` APIs with strongly typed handlers.
- Decode typed-data collections while preserving empty entries and per-message metadata alignment.
- Configure Event Hubs and Service Bus trigger payloads as binary for both single-message and batch handlers, preventing non-UTF-8 payload corruption.
- Update samples, emulator configuration, documentation, and integration coverage.

## Breaking change and release notes

- **Cosmos DB trigger fix:** `CosmosDocument.Timestamp` changes from `string` to `int64`. Cosmos DB emits `_ts` as a JSON number, so the previous public type caused real change-feed documents to fail decoding on both JSON and string input paths. Consumers assigning or comparing `Timestamp` as a string must update their code.
- **Event Hubs and Service Bus payload fix:** trigger bindings now request binary data. Existing single-message handlers, as well as new batch handlers, receive the original bytes instead of UTF-8 replacement bytes for protobuf, Avro, compressed, or other non-text payloads.
- Queue, Service Bus, and Event Hub message bodies consistently marshal under the public JSON property `body`; the worker-specific raw-data marker is carried by `azfunc:"data"`.

## Testing

- Added unit tests for batch conversion, empty-entry alignment, metadata precedence, malformed extension metadata, bindings, and handler invocation.
- Expanded Event Hub and Service Bus integration tests for single and batch delivery.
- The checked-in integration runner remains scoped to the HTTP/Azurite milestone; Event Hubs, Service Bus, and Cosmos DB integration tests run when their emulator stack is started explicitly as documented in `tests/integration/README.md`.

Fixes #46