### PR TITLE
 docs: add roadmap and host-worker architecture guidance

### DIFF
--- a/docs/assets/host-worker-visualization.html
+++ b/docs/assets/host-worker-visualization.html
@@ -1,0 +1,1519 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light">
+  <link rel="icon" href="data:,">
+  <title>Azure Functions Host and Go Worker</title>
+  <script>
+    try {
+      const scheme = window.parent.document.body.getAttribute("data-md-color-scheme");
+      document.documentElement.dataset.theme = scheme === "slate" ? "dark" : "light";
+    } catch {
+      document.documentElement.dataset.theme =
+        window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+  </script>
+  <style>
+    :root {
+      --bg: #f4f8fc;
+      --surface: #ffffff;
+      --surface-subtle: #f7fafc;
+      --surface-active: #deedf8;
+      --code-bg: #edf4f9;
+      --code-text: #294b67;
+      --button-bg: #edf4f9;
+      --button-hover: #d6e8f5;
+      --panel-strong: #e6f0f8;
+      --line: rgba(65, 96, 126, 0.18);
+      --text: #10243a;
+      --muted: #526b82;
+      --canvas-bg: #ffffff;
+      --container-bg: #f8fafc;
+      --canvas-border: #9eb6c9;
+      --node-bg: #ffffff;
+      --node-active: #eaf4fb;
+      --worker-bg: #f7fbfc;
+      --worker-active: #edfafa;
+      --inner-active: #d8f0f2;
+      --pipe-active: #d9cff2;
+      --pipe-inactive: #dbe5ec;
+      --pipe-core: #ffffff;
+      --canvas-text: #16344c;
+      --canvas-muted: #607b92;
+      --azure: #0078d4;
+      --go: #007f91;
+      --control: #7655c7;
+      --invoke: #c65f00;
+      --response: #16853b;
+      --log: #a76b00;
+      --danger: #c4314b;
+    }
+
+    :root[data-theme="dark"] {
+      color-scheme: dark;
+      --bg: #111820;
+      --surface: #1d2731;
+      --surface-subtle: #17212a;
+      --surface-active: #263b4d;
+      --code-bg: #111a22;
+      --code-text: #c5d9e8;
+      --button-bg: #263541;
+      --button-hover: #314555;
+      --panel-strong: #2a3946;
+      --line: rgba(205, 224, 239, 0.18);
+      --text: #edf5fb;
+      --muted: #a8bac9;
+      --canvas-bg: #18222b;
+      --container-bg: #1c2933;
+      --canvas-border: #587184;
+      --node-bg: #202d38;
+      --node-active: #263d50;
+      --worker-bg: #1d3037;
+      --worker-active: #203b41;
+      --inner-active: #29484e;
+      --pipe-active: #4c4267;
+      --pipe-inactive: #33434f;
+      --pipe-core: #1b252e;
+      --canvas-text: #e8f2f8;
+      --canvas-muted: #9db1c0;
+      --azure: #4bb3ff;
+      --go: #58d8e5;
+      --control: #b69cff;
+      --invoke: #ffad66;
+      --response: #5ed47b;
+      --log: #f4cc5d;
+      --danger: #ff8196;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      margin: 0;
+      min-height: 100%;
+      background: var(--bg);
+      color: var(--text);
+      font-family: "Segoe UI", Inter, system-ui, sans-serif;
+    }
+
+    body {
+      padding: clamp(14px, 2vw, 28px);
+    }
+
+    button,
+    input {
+      font: inherit;
+    }
+
+    .shell {
+      width: min(1500px, 100%);
+      margin: 0 auto;
+    }
+
+    .workspace {
+      display: grid;
+      grid-template-columns: 1fr;
+      min-height: 0;
+      overflow: hidden;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: var(--surface);
+    }
+
+    .message-legend {
+      display: grid;
+      grid-template-columns: 180px minmax(0, 1fr);
+      gap: 12px;
+      align-items: center;
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--line);
+      background: var(--surface-subtle);
+    }
+
+    .message-legend h2 {
+      margin: 0;
+      font-size: 0.82rem;
+    }
+
+    .message-kind {
+      width: 100%;
+      min-height: 0;
+      padding: 7px 8px;
+      border: 0;
+      border-left: 3px solid var(--message-color);
+      border-radius: 0;
+      background: transparent;
+      color: var(--muted);
+      cursor: default;
+      line-height: 1.35;
+      text-align: left;
+      overflow-wrap: anywhere;
+    }
+
+    .message-legend-list {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 8px;
+    }
+
+    .message-friendly,
+    .message-proto {
+      display: block;
+    }
+
+    .message-friendly {
+      color: var(--text);
+      font-size: 0.72rem;
+      font-weight: 650;
+    }
+
+    .message-proto {
+      margin-top: 2px;
+      font-family: "Cascadia Code", "SFMono-Regular", Consolas, monospace;
+      font-size: 0.58rem;
+    }
+
+    .message-kind:hover {
+      border-color: var(--message-color);
+      background: transparent;
+    }
+
+    .message-kind.active {
+      background: var(--surface-active);
+      color: var(--text);
+      font-weight: 700;
+    }
+
+    .journeys {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+      margin-bottom: 12px;
+    }
+
+    .journeys button {
+      display: flex;
+      min-height: 58px;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 14px;
+      background: var(--surface);
+      text-align: left;
+    }
+
+    .journeys button.active {
+      border-color: var(--azure);
+      background: var(--surface-active);
+    }
+
+    .journey-index {
+      display: grid;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 auto;
+      place-items: center;
+      border-radius: 3px;
+      background: var(--panel-strong);
+      color: var(--muted);
+      font-size: 0.78rem;
+      font-weight: 800;
+    }
+
+    .journeys button.active .journey-index {
+      background: var(--azure);
+      color: #fff;
+    }
+
+    .journey-copy strong,
+    .journey-copy small {
+      display: block;
+    }
+
+    .journey-copy strong {
+      color: var(--text);
+      font-size: 0.82rem;
+    }
+
+    .journey-copy small {
+      margin-top: 3px;
+      color: var(--muted);
+      font-size: 0.7rem;
+    }
+
+    .stage {
+      position: relative;
+      min-width: 0;
+      border-bottom: 1px solid var(--line);
+    }
+
+    canvas {
+      display: block;
+      width: 100%;
+      height: 380px;
+    }
+
+    aside {
+      display: flex;
+      min-width: 0;
+      flex-direction: column;
+      background: var(--surface-subtle);
+    }
+
+    .details {
+      padding: 24px 22px 18px;
+      border-top: 4px solid var(--active-color, var(--azure));
+      background: var(--surface);
+    }
+
+    .explanation-panel {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 280px;
+      align-self: stretch;
+      background: var(--surface);
+    }
+
+    .explanation-label {
+      margin-bottom: 10px;
+      color: var(--muted);
+      font-size: 0.65rem;
+      font-weight: 750;
+      letter-spacing: 0.09em;
+      text-transform: uppercase;
+    }
+
+    .diagram-caption {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.82rem;
+      line-height: 1.5;
+    }
+
+    .details h2 {
+      margin: 8px 0 10px;
+      font-size: 1.35rem;
+      line-height: 1.18;
+      letter-spacing: -0.02em;
+    }
+
+    .technical-details {
+      margin-top: 16px;
+      border-top: 1px solid var(--line);
+    }
+
+    .technical-details summary {
+      padding: 10px 0;
+      color: var(--muted);
+      cursor: pointer;
+      font-size: 0.72rem;
+      font-weight: 650;
+    }
+
+    .message-card {
+      margin-top: 0;
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-left: 3px solid var(--control);
+      border-radius: 4px;
+      background: var(--surface);
+    }
+
+    .message-label {
+      color: var(--muted);
+      font-size: 0.66rem;
+      font-weight: 700;
+      letter-spacing: 0.11em;
+      text-transform: uppercase;
+    }
+
+    .message-name {
+      margin-top: 5px;
+      overflow-wrap: anywhere;
+      font-family: "Cascadia Code", "SFMono-Regular", Consolas, monospace;
+      font-size: 0.84rem;
+      font-weight: 650;
+    }
+
+    .payload {
+      margin: 10px 0 0;
+      padding: 11px;
+      overflow: auto;
+      border-radius: 3px;
+      background: var(--code-bg);
+      color: var(--code-text);
+      font-family: "Cascadia Code", "SFMono-Regular", Consolas, monospace;
+      font-size: 0.7rem;
+      line-height: 1.55;
+      white-space: pre-wrap;
+    }
+
+    .source {
+      margin-top: 13px;
+      color: var(--muted);
+      font-size: 0.68rem;
+      line-height: 1.45;
+    }
+
+    .controls {
+      display: flex;
+      align-items: center;
+      padding: 17px 20px 20px;
+      border-left: 1px solid var(--line);
+      background: var(--surface);
+    }
+
+    .button-row {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 14px;
+    }
+
+    .button-row button {
+      display: grid;
+      width: 38px;
+      height: 38px;
+      min-height: 38px;
+      padding: 0;
+      place-items: center;
+      border-radius: 50%;
+    }
+
+    .button-row svg {
+      width: 18px;
+      height: 18px;
+    }
+
+    button {
+      min-height: 38px;
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      background: var(--button-bg);
+      color: var(--text);
+      cursor: pointer;
+    }
+
+    button:hover {
+      border-color: rgba(84, 215, 232, 0.55);
+      background: var(--button-hover);
+    }
+
+    button:focus-visible,
+    input:focus-visible {
+      outline: 2px solid var(--go);
+      outline-offset: 2px;
+    }
+
+    #play {
+      width: 46px;
+      height: 46px;
+      min-width: 46px;
+      min-height: 46px;
+      border-color: rgba(57, 169, 255, 0.45);
+      background: var(--azure);
+      color: #fff;
+      font-weight: 700;
+    }
+
+    .timeline-wrap {
+      margin: -4px 0 12px;
+    }
+
+    .timeline {
+      display: flex;
+      gap: 6px;
+      padding: 0;
+      overflow-x: auto;
+      scrollbar-width: thin;
+      scrollbar-color: var(--panel-strong) transparent;
+    }
+
+    .timeline button {
+      position: relative;
+      min-width: 140px;
+      min-height: 32px;
+      padding: 7px 10px 7px 14px;
+      border-radius: 3px;
+      color: var(--muted);
+      font-size: 0.74rem;
+      text-align: left;
+      white-space: nowrap;
+    }
+
+    .timeline button::before {
+      position: absolute;
+      top: 7px;
+      bottom: 7px;
+      left: 4px;
+      width: 2px;
+      border-radius: 2px;
+      background: var(--step-color, var(--control));
+      content: "";
+    }
+
+    .timeline button.active {
+      border-color: var(--step-color, var(--control));
+      background: var(--surface-active);
+      color: var(--text);
+    }
+
+    .timeline button.visited {
+      color: var(--muted);
+    }
+
+    @media (max-width: 1100px) {
+      .message-kind {
+        padding: 4px 6px;
+      }
+
+      canvas {
+        height: 360px;
+      }
+
+      .details {
+        padding: 12px;
+      }
+
+      .details h2 {
+        margin: 6px 0 8px;
+        font-size: 1.1rem;
+      }
+
+      .message-card {
+        margin-top: 9px;
+        padding: 8px;
+      }
+
+      .payload {
+        max-height: 90px;
+        margin-top: 7px;
+        padding: 6px;
+      }
+
+      .source {
+        margin-top: 8px;
+      }
+
+      .controls {
+        padding: 12px;
+      }
+
+    }
+
+    @media (max-width: 650px) {
+      .journeys {
+        grid-template-columns: 1fr;
+      }
+
+      .message-legend {
+        display: block;
+        padding: 10px 12px;
+      }
+
+      .message-legend-list {
+        margin-top: 8px;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .explanation-panel {
+        grid-template-columns: 1fr;
+      }
+
+      .controls {
+        border-top: 1px solid var(--line);
+        border-left: 0;
+      }
+
+      canvas {
+        height: 400px;
+      }
+
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      * {
+        scroll-behavior: auto !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <nav class="journeys" id="journeys" aria-label="Choose a protocol story"></nav>
+    <div class="timeline-wrap">
+      <nav class="timeline" id="timeline" aria-label="Phases in the selected story"></nav>
+    </div>
+
+    <section class="workspace">
+      <aside class="message-legend" aria-label="Messages sent by the host">
+        <h2>Host requests</h2>
+        <div class="message-legend-list" id="host-message-legend"></div>
+      </aside>
+
+      <div class="stage">
+        <canvas id="canvas" role="img" aria-label="Animated Azure Functions host and Go worker protocol diagram"></canvas>
+      </div>
+
+      <aside class="explanation-panel">
+        <div class="details" aria-live="polite">
+          <div class="explanation-label">What's happening</div>
+          <h2 id="step-title"></h2>
+          <p class="diagram-caption" id="diagram-caption"></p>
+          <details class="technical-details">
+            <summary id="technical-summary">More details</summary>
+            <div class="message-card" id="message-card">
+              <div class="message-label" id="message-label">StreamingMessage</div>
+              <div class="message-name" id="message-name"></div>
+              <pre class="payload" id="payload"></pre>
+            </div>
+            <div class="source" id="source"></div>
+          </details>
+        </div>
+
+        <div class="controls">
+          <div class="button-row">
+            <button id="previous" type="button" title="Previous step" aria-label="Previous step">
+              <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M15 18l-6-6 6-6"></path>
+              </svg>
+            </button>
+            <button id="play" type="button" title="Pause" aria-label="Pause">
+              <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+                <rect x="6" y="5" width="4" height="14" rx="1"></rect>
+                <rect x="14" y="5" width="4" height="14" rx="1"></rect>
+              </svg>
+            </button>
+            <button id="next" type="button" title="Next step" aria-label="Next step">
+              <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M9 6l6 6-6 6"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+      </aside>
+    </section>
+  </main>
+
+  <script>
+    (() => {
+      "use strict";
+
+      const COLORS = {};
+      const CANVAS_THEME = {};
+      const PLAY_ICONS = {
+        play: '<svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"></path></svg>',
+        pause: '<svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="5" width="4" height="14" rx="1"></rect><rect x="14" y="5" width="4" height="14" rx="1"></rect></svg>',
+        replay: '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 11a8 8 0 1 1 2.3 5.7"></path><path d="M4 5v6h6"></path></svg>'
+      };
+
+      const steps = [
+        {
+          short: "Launch",
+          title: "Host launches the Go Function App",
+          description: "The Functions host starts the customer's compiled Go application with the worker ID, request ID, gRPC address, and message-size settings in its startup environment.",
+          type: "control",
+          from: "host",
+          to: "worker",
+          message: "Worker process",
+          label: "Process lifecycle",
+          payload: "FUNCTIONS_WORKER_ID=go-worker-1\nFUNCTIONS_URI=127.0.0.1:5001\nFUNCTIONS_REQUEST_ID=req-startup",
+          source: "Host: RpcWorkerProcess | Worker: worker/config.go",
+          duration: 2400
+        },
+        {
+          short: "Connect",
+          title: "Worker opens the event stream",
+          description: "The Go worker creates a gRPC client and opens FunctionRpc.EventStream. The first message must register this process with its assigned worker ID.",
+          type: "control",
+          from: "worker",
+          to: "host",
+          message: "StartStream",
+          payload: '{\n  "worker_id": "go-worker-1"\n}',
+          source: "worker/grpc.go: connectToHost, sendStartStreamMessage",
+          duration: 2200
+        },
+        {
+          short: "Initialize",
+          title: "Host initializes the worker",
+          description: "After accepting StartStream, the host sends configuration, environment information, and log-category thresholds over the established bidirectional channel.",
+          type: "control",
+          from: "host",
+          to: "dispatcher",
+          message: "WorkerInitRequest",
+          payload: '{\n  "host_version": "4.x",\n  "function_app_directory": "...",\n  "log_categories": { "Worker": "Information" }\n}',
+          source: "Host: GrpcWorkerChannel | Worker: worker/dispatcher.go",
+          duration: 2600
+        },
+        {
+          short: "Capabilities",
+          title: "Worker advertises capabilities",
+          description: "The worker confirms readiness and tells the host which protocol features it supports, including typed collections, worker status, raw HTTP bodies, and optional HTTP streaming.",
+          type: "response",
+          from: "dispatcher",
+          to: "host",
+          message: "WorkerInitResponse",
+          payload: '{\n  "status": "Success",\n  "worker_version": "1.0.0",\n  "capabilities": {\n    "TypedDataCollection": "true",\n    "WorkerStatus": "true",\n    "RpcHttpBodyOnly": "true"\n  }\n}',
+          source: "worker/handlers.go: handleWorkerInitRequest",
+          duration: 2800
+        },
+        {
+          short: "Index",
+          title: "Host asks for function metadata",
+          description: "For worker-driven indexing, the host asks the Go process to describe the functions registered through the SDK.",
+          type: "control",
+          from: "host",
+          to: "dispatcher",
+          message: "FunctionsMetadataRequest",
+          payload: '{\n  "function_app_directory": "..."\n}',
+          source: "worker/dispatcher.go: processRequestMessage",
+          duration: 2200
+        },
+        {
+          short: "Metadata",
+          title: "Worker returns registered functions",
+          description: "The SDK registration map is converted into RPC metadata containing each function ID, name, trigger, bindings, script file, and entry point.",
+          type: "response",
+          from: "dispatcher",
+          to: "host",
+          message: "FunctionMetadataResponse",
+          payload: '{\n  "functions": [{\n    "name": "processOrder",\n    "language": "go",\n    "bindings": ["queueTrigger"]\n  }],\n  "status": "Success"\n}',
+          source: "worker/handlers.go: handleFunctionsMetadataRequest",
+          duration: 2800
+        },
+        {
+          short: "Load",
+          title: "Host loads the selected function",
+          description: "The host uses the stable function ID supplied in worker metadata and asks the worker to prepare that function before any invocation is dispatched.",
+          type: "control",
+          from: "host",
+          to: "dispatcher",
+          message: "FunctionLoadRequest",
+          payload: '{\n  "function_id": "fn-process-order",\n  "metadata": { "name": "processOrder" }\n}',
+          source: "worker/handlers.go: handleFunctionLoadRequest",
+          duration: 2300
+        },
+        {
+          short: "Ready",
+          title: "Worker caches the function shape",
+          description: "Reflection maps trigger inputs, output bindings, context parameters, and HTTP response writers. The resulting LoadedFunction is cached for later invocations.",
+          type: "response",
+          from: "dispatcher",
+          to: "host",
+          message: "FunctionLoadResponse",
+          payload: '{\n  "function_id": "fn-process-order",\n  "status": "Success"\n}',
+          source: "worker/handlers.go: LoadedFunction, handleFunctionLoadRequest",
+          duration: 2400
+        },
+        {
+          short: "Trigger",
+          title: "A trigger wakes the host",
+          description: "A queue message, timer, event, or other binding source is accepted by the host and matched to the loaded function.",
+          type: "invoke",
+          from: "trigger",
+          to: "host",
+          message: "Queue message: order-42",
+          label: "Trigger event",
+          payload: '{\n  "order_id": "order-42",\n  "customer": "contoso"\n}',
+          source: "Host trigger and binding pipeline",
+          duration: 2200
+        },
+        {
+          short: "Invoke",
+          title: "Host dispatches an invocation",
+          description: "The InvocationRequest carries correlation IDs, trigger metadata, input bindings, retry context, and distributed tracing information.",
+          type: "invoke",
+          from: "host",
+          to: "dispatcher",
+          message: "InvocationRequest",
+          payload: '{\n  "invocation_id": "inv-42",\n  "function_id": "fn-process-order",\n  "input_data": [{ "name": "message", "string": "{...}" }],\n  "trace_context": { "trace_parent": "00-4bf92f..." }\n}',
+          source: "Host: ScriptInvocationContextExtensions | Worker: worker/dispatcher.go",
+          duration: 3000
+        },
+        {
+          short: "Convert",
+          title: "Bindings become Go values",
+          description: "The dispatcher finds the cached function. FromProto converts RPC TypedData and trigger metadata into the strongly typed arguments expected by the Go handler.",
+          type: "invoke",
+          from: "dispatcher",
+          to: "converter",
+          message: "TypedData -> Go values",
+          label: "In-process stage",
+          payload: "TypedData.String -> string\nInvocationContext -> context.Context",
+          source: "worker/converter.go and worker/handlers.go",
+          duration: 2500
+        },
+        {
+          short: "Middleware",
+          title: "Middleware wraps the handler",
+          description: "The worker builds a MiddlewareContext, composes the registered middleware chain, and propagates invocation and trace context into user code.",
+          type: "invoke",
+          from: "converter",
+          to: "middleware",
+          message: "App.Compose(handler)",
+          label: "In-process stage",
+          payload: "middleware[0]\n  -> middleware[1]\n    -> user handler",
+          source: "sdk/middleware.go and worker/invocation.go",
+          duration: 2300
+        },
+        {
+          short: "Execute",
+          title: "The Go function executes",
+          description: "The handler runs concurrently with other invocations. Returned errors and recovered panics are converted into an RPC StatusResult instead of crashing the worker.",
+          type: "invoke",
+          from: "middleware",
+          to: "function",
+          message: "processOrder(ctx, message)",
+          label: "User code",
+          payload: 'orderID := parseOrderID(message)\nreturn process(ctx, orderID)',
+          source: "worker/handlers.go: handleInvocationRequest",
+          duration: 3100
+        },
+        {
+          short: "Logs",
+          title: "Logs flow independently",
+          description: "User and system slog records become RpcLog messages. A single sender goroutine serializes logs and responses onto the same gRPC stream.",
+          type: "log",
+          from: "function",
+          to: "host",
+          message: "RpcLog",
+          payload: '{\n  "invocation_id": "inv-42",\n  "category": "Function.processOrder",\n  "level": "Information",\n  "message": "Processing order-42"\n}',
+          source: "worker/log/writer.go and worker/grpc.go: startSender",
+          duration: 2600
+        },
+        {
+          short: "Respond",
+          title: "Worker returns invocation results",
+          description: "The response echoes the invocation and request correlation, then returns status, output bindings, an optional HTTP response, and outbound trace attributes.",
+          type: "response",
+          from: "function",
+          to: "host",
+          message: "InvocationResponse",
+          payload: '{\n  "invocation_id": "inv-42",\n  "status": "Success"\n}',
+          source: "worker/handlers.go: handleInvocationRequest",
+          duration: 3200
+        },
+        {
+          short: "Complete",
+          title: "Host completes the trigger",
+          description: "The host applies output bindings, records invocation telemetry, and completes the original trigger. The worker remains connected and ready for more concurrent requests.",
+          type: "response",
+          from: "host",
+          to: "trigger",
+          message: "Queue message completed",
+          label: "Trigger completion",
+          payload: "order-42 checkpointed and removed from the queue",
+          source: "Host invocation and binding pipeline",
+          duration: 2800
+        }
+      ];
+
+      const diagramCaptions = [
+        "The host starts the compiled Go Function App inside the Functions container.",
+        "The worker opens the gRPC pipe and registers its worker ID.",
+        "The host sends initialization settings through the pipe.",
+        "The worker confirms that it is ready and advertises its capabilities.",
+        "The host asks the worker which Go functions are registered.",
+        "The worker returns the functions and their trigger and binding metadata.",
+        "The host asks the worker to prepare a specific function.",
+        "The worker records the function as loaded and ready for requests.",
+        "A customer request or event reaches the Functions host.",
+        "The host dispatches the customer invocation to the Go worker.",
+        "The worker converts the RPC payload into the Go handler's input values.",
+        "Registered middleware wraps the customer function.",
+        "The customer-defined Go function executes.",
+        "Function logs travel back to the host independently of the result.",
+        "The worker sends the invocation result back through the gRPC pipe.",
+        "The host completes the original customer request or trigger."
+      ];
+
+      const journeys = [
+        {
+          title: "Go app startup and handshake",
+          summary: "Container startup, gRPC registration, indexing, and load",
+          start: 0,
+          end: 7,
+          phases: [
+            { title: "Connect and initialize", start: 0, end: 3, type: "control" },
+            { title: "Discover and load functions", start: 4, end: 7, type: "control" }
+          ]
+        },
+        {
+          title: "Customer request processing",
+          summary: "Primary gRPC payload path: trigger, execution, logs, and response",
+          start: 8,
+          end: 15,
+          phases: [
+            { title: "Dispatch trigger", start: 8, end: 9, type: "invoke" },
+            { title: "Run Go function", start: 10, end: 13, type: "invoke" },
+            { title: "Return result", start: 14, end: 15, type: "response" }
+          ]
+        }
+      ];
+
+      const hostMessagesByJourney = [
+        [
+          { label: "Initialize worker", name: "WorkerInitRequest", type: "control" },
+          { label: "List functions", name: "FunctionsMetadataRequest", type: "control" },
+          { label: "Load function", name: "FunctionLoadRequest", type: "control" }
+        ],
+        [
+          { label: "Dispatch invocation", name: "InvocationRequest", type: "invoke" }
+        ]
+      ];
+
+      const canvas = document.getElementById("canvas");
+      const ctx = canvas.getContext("2d");
+      const hostMessageLegend = document.getElementById("host-message-legend");
+      const detailsPanel = document.querySelector(".details");
+      const journeyNav = document.getElementById("journeys");
+      const timeline = document.getElementById("timeline");
+      const playButton = document.getElementById("play");
+      const previousButton = document.getElementById("previous");
+      const nextButton = document.getElementById("next");
+      const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+      let currentStep = 0;
+      let activeJourney = 0;
+      let stepStartedAt = performance.now();
+      let pausedAt = 0;
+      let playing = !reducedMotion;
+      const speed = 0.65;
+      let width = 0;
+      let height = 0;
+      let dpr = 1;
+      let nodes = {};
+
+      function cssVar(name) {
+        return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+      }
+
+      function refreshThemeColors() {
+        Object.assign(COLORS, {
+          control: cssVar("--control"),
+          invoke: cssVar("--invoke"),
+          response: cssVar("--response"),
+          log: cssVar("--log"),
+          azure: cssVar("--azure"),
+          go: cssVar("--go"),
+          danger: cssVar("--danger")
+        });
+        Object.assign(CANVAS_THEME, {
+          surface: cssVar("--surface"),
+          surfaceActive: cssVar("--surface-active"),
+          background: cssVar("--canvas-bg"),
+          container: cssVar("--container-bg"),
+          border: cssVar("--canvas-border"),
+          node: cssVar("--node-bg"),
+          nodeActive: cssVar("--node-active"),
+          worker: cssVar("--worker-bg"),
+          workerActive: cssVar("--worker-active"),
+          innerActive: cssVar("--inner-active"),
+          pipeActive: cssVar("--pipe-active"),
+          pipeInactive: cssVar("--pipe-inactive"),
+          pipeCore: cssVar("--pipe-core"),
+          text: cssVar("--canvas-text"),
+          muted: cssVar("--canvas-muted")
+        });
+        if (detailsPanel && steps[currentStep]) {
+          detailsPanel.style.setProperty("--active-color", COLORS[steps[currentStep].type]);
+        }
+        if (timeline.children.length) {
+          createHostMessageLegend();
+          renderTimeline();
+          updateHostMessageLegend();
+          updateTimeline();
+        }
+      }
+
+      function syncTheme() {
+        let dark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        try {
+          dark = window.parent.document.body.getAttribute("data-md-color-scheme") === "slate";
+        } catch {
+          // Standalone pages follow the operating-system preference.
+        }
+        document.documentElement.dataset.theme = dark ? "dark" : "light";
+        refreshThemeColors();
+      }
+
+      function watchTheme() {
+        try {
+          const parentBody = window.parent.document.body;
+          new MutationObserver(syncTheme).observe(parentBody, {
+            attributes: true,
+            attributeFilter: ["data-md-color-scheme"]
+          });
+        } catch {
+          window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", syncTheme);
+        }
+      }
+
+      function setPlayButton(state) {
+        const label = state === "pause" ? "Pause" : state === "replay" ? "Replay" : "Play";
+        playButton.innerHTML = PLAY_ICONS[state];
+        playButton.title = label;
+        playButton.setAttribute("aria-label", label);
+      }
+
+      function createJourneyNav() {
+        journeys.forEach((journey, index) => {
+          const button = document.createElement("button");
+          button.type = "button";
+          button.innerHTML =
+            `<span class="journey-index">${index + 1}</span>` +
+            `<span class="journey-copy"><strong>${journey.title}</strong><small>${journey.summary}</small></span>`;
+          button.addEventListener("click", () => setJourney(index));
+          journeyNav.appendChild(button);
+        });
+      }
+
+      function createHostMessageLegend() {
+        hostMessageLegend.replaceChildren();
+        hostMessagesByJourney[activeJourney].forEach(message => {
+          const item = document.createElement("div");
+          item.className = "message-kind";
+          item.dataset.message = message.name;
+          item.style.setProperty("--message-color", COLORS[message.type]);
+          item.innerHTML =
+            `<span class="message-friendly">${message.label}</span>` +
+            `<span class="message-proto">${message.name}</span>`;
+          hostMessageLegend.appendChild(item);
+        });
+      }
+
+      function updateHostMessageLegend() {
+        const step = steps[currentStep];
+        [...hostMessageLegend.querySelectorAll(".message-kind")].forEach(item => {
+          item.classList.toggle(
+            "active",
+            step.from === "host" && item.dataset.message === step.message
+          );
+        });
+      }
+
+      function renderTimeline() {
+        timeline.replaceChildren();
+        journeys[activeJourney].phases.forEach((phase, index) => {
+          const button = document.createElement("button");
+          button.type = "button";
+          button.textContent = `${index + 1}. ${phase.title}`;
+          button.style.setProperty("--step-color", COLORS[phase.type]);
+          button.addEventListener("click", () => setStep(phase.start, true));
+          timeline.appendChild(button);
+        });
+      }
+
+      function phaseForStep(stepIndex) {
+        return journeys[activeJourney].phases.findIndex(
+          phase => stepIndex >= phase.start && stepIndex <= phase.end
+        );
+      }
+
+      function setJourney(index) {
+        activeJourney = index;
+        layoutNodes();
+        createHostMessageLegend();
+        renderTimeline();
+        playing = true;
+        setPlayButton("pause");
+        setStep(journeys[index].start, true);
+        updateJourneyNav();
+      }
+
+      function updateJourneyNav() {
+        [...journeyNav.children].forEach((button, index) => {
+          button.classList.toggle("active", index === activeJourney);
+          button.setAttribute("aria-current", index === activeJourney ? "true" : "false");
+        });
+      }
+
+      function moveStep(delta) {
+        const journey = journeys[activeJourney];
+        let next = currentStep + delta;
+        if (next > journey.end) {
+          next = journey.start;
+        } else if (next < journey.start) {
+          next = journey.end;
+        }
+        setStep(next, true);
+      }
+
+      function setStep(index, resetClock) {
+        currentStep = (index + steps.length) % steps.length;
+        if (resetClock) {
+          stepStartedAt = performance.now();
+          pausedAt = 0;
+        }
+        updateDetails();
+        updateTimeline();
+      }
+
+      function updateDetails() {
+        const step = steps[currentStep];
+        detailsPanel.style.setProperty("--active-color", COLORS[step.type]);
+        document.getElementById("diagram-caption").textContent = diagramCaptions[currentStep];
+        document.getElementById("step-title").textContent = step.title;
+        document.getElementById("message-label").textContent = step.label || "StreamingMessage";
+        document.getElementById("message-name").textContent = step.message;
+        document.getElementById("payload").textContent = step.payload;
+        document.getElementById("source").textContent = `Code reference: ${step.source}`;
+        document.getElementById("technical-summary").textContent =
+          step.message.includes("Request") ? "See request" : "More details";
+        document.getElementById("message-card").style.borderLeftColor = COLORS[step.type];
+        updateHostMessageLegend();
+        if (!reducedMotion) {
+          detailsPanel.animate(
+            [
+              { backgroundColor: CANVAS_THEME.surfaceActive },
+              { backgroundColor: CANVAS_THEME.surface }
+            ],
+            { duration: 500, easing: "ease-out" }
+          );
+        }
+      }
+
+      function updateTimeline() {
+        const activePhase = phaseForStep(currentStep);
+        [...timeline.children].forEach((button, index) => {
+          button.classList.toggle("active", index === activePhase);
+          button.classList.toggle("visited", index < activePhase);
+          if (index === activePhase) {
+            button.scrollIntoView({ behavior: reducedMotion ? "auto" : "smooth", block: "nearest", inline: "center" });
+          }
+        });
+      }
+
+      function togglePlaying() {
+        const now = performance.now();
+        if (playing) {
+          pausedAt = now;
+          playing = false;
+        } else {
+          const journey = journeys[activeJourney];
+          const duration = steps[currentStep].duration / speed;
+          if (currentStep === journey.end && pausedAt - stepStartedAt >= duration) {
+            setStep(journey.start, true);
+          } else {
+            stepStartedAt += now - pausedAt;
+          }
+          pausedAt = 0;
+          playing = true;
+        }
+        setPlayButton(playing ? "pause" : "play");
+      }
+
+      function resize() {
+        const rect = canvas.getBoundingClientRect();
+        dpr = Math.min(window.devicePixelRatio || 1, 2);
+        width = rect.width;
+        height = rect.height;
+        canvas.width = Math.round(width * dpr);
+        canvas.height = Math.round(height * dpr);
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        layoutNodes();
+      }
+
+      function layoutNodes() {
+        const compact = width < 760;
+        if (compact) {
+          nodes = {
+            trigger: { x: 44, y: height * 0.54, w: 66, h: 58, label: "Trigger", sub: "HTTP / event" },
+            host: { x: width * 0.3, y: height * 0.54, w: 124, h: 126, label: "Functions Host", sub: "Triggers + bindings" },
+            grpc: { x: width * 0.51, y: height * 0.54, w: 72, h: 160, label: "gRPC", sub: "EventStream" },
+            worker: {
+              x: width * 0.76,
+              y: height * 0.54,
+              w: Math.min(235, width * 0.36),
+              h: activeJourney === 0 ? 200 : 280,
+              label: "Go Function App",
+              sub: "Compiled customer app"
+            }
+          };
+        } else {
+          nodes = {
+            trigger: { x: width * 0.08, y: height * 0.54, w: 88, h: 64, label: "Trigger", sub: "HTTP / event" },
+            host: { x: width * 0.25, y: height * 0.54, w: 150, h: 150, label: "Functions Host", sub: "Triggers + bindings" },
+            grpc: { x: width * 0.48, y: height * 0.54, w: 82, h: 200, label: "gRPC", sub: "EventStream" },
+            worker: {
+              x: width * 0.76,
+              y: height * 0.54,
+              w: Math.min(300, width * 0.34),
+              h: activeJourney === 0 ? 220 : 280,
+              label: "Go Function App",
+              sub: "Compiled customer app"
+            }
+          };
+        }
+
+        const worker = nodes.worker;
+        const innerWidth = worker.w * 0.72;
+        const innerHeight = compact ? 36 : 42;
+
+        if (activeJourney === 0) {
+          const offset = compact ? 30 : 38;
+          nodes.dispatcher = {
+            x: worker.x,
+            y: worker.y - offset,
+            w: innerWidth,
+            h: innerHeight,
+            label: "gRPC dispatcher",
+            sub: "Routes host messages"
+          };
+          nodes.registry = {
+            x: worker.x,
+            y: worker.y + offset,
+            w: innerWidth,
+            h: innerHeight,
+            label: "Function registry",
+            sub: "Metadata + load state"
+          };
+          return;
+        }
+
+        const firstY = worker.y - worker.h * 0.24;
+        const gap = compact ? 46 : 48;
+        nodes.dispatcher = { x: worker.x, y: firstY, w: innerWidth, h: innerHeight, label: "Dispatcher", sub: "Route message" };
+        nodes.converter = { x: worker.x, y: firstY + gap, w: innerWidth, h: innerHeight, label: "Converter", sub: "TypedData -> Go" };
+        nodes.middleware = { x: worker.x, y: firstY + gap * 2, w: innerWidth, h: innerHeight, label: "Middleware", sub: "Compose chain" };
+        nodes.function = { x: worker.x, y: firstY + gap * 3, w: innerWidth, h: innerHeight, label: "User function", sub: "processOrder(ctx, message)" };
+      }
+
+      function roundedRect(x, y, w, h, radius) {
+        const r = Math.min(radius, w / 2, h / 2);
+        ctx.beginPath();
+        ctx.moveTo(x + r, y);
+        ctx.arcTo(x + w, y, x + w, y + h, r);
+        ctx.arcTo(x + w, y + h, x, y + h, r);
+        ctx.arcTo(x, y + h, x, y, r);
+        ctx.arcTo(x, y, x + w, y, r);
+        ctx.closePath();
+      }
+
+      function drawBaseConnections() {
+        const links = activeJourney === 1 ? [["trigger", "host"]] : [];
+        ctx.save();
+        ctx.lineWidth = 2;
+        ctx.setLineDash([5, 8]);
+        ctx.strokeStyle = CANVAS_THEME.border;
+        links.forEach(([from, to]) => {
+          const a = nodes[from];
+          const b = nodes[to];
+          ctx.beginPath();
+          ctx.moveTo(a.x + a.w / 2, a.y);
+          ctx.lineTo(b.x - b.w / 2, b.y);
+          ctx.stroke();
+        });
+        ctx.setLineDash([]);
+        ctx.restore();
+      }
+
+      function drawContainer() {
+        const host = nodes.host;
+        const worker = nodes.worker;
+        const left = host.x - host.w / 2 - 12;
+        const right = worker.x + worker.w / 2 + 26;
+        const top = Math.min(host.y - host.h / 2, worker.y - worker.h / 2) - 48;
+        const bottom = Math.max(host.y + host.h / 2, worker.y + worker.h / 2) + 24;
+
+        ctx.save();
+        roundedRect(left, top, right - left, bottom - top, 8);
+        ctx.fillStyle = CANVAS_THEME.container;
+        ctx.fill();
+        ctx.strokeStyle = CANVAS_THEME.border;
+        ctx.lineWidth = 1;
+        ctx.stroke();
+        ctx.fillStyle = CANVAS_THEME.text;
+        ctx.font = '750 10px "Segoe UI", sans-serif';
+        ctx.textAlign = "left";
+        ctx.fillText("AZURE FUNCTIONS CONTAINER", left + 18, top + 24);
+        ctx.fillStyle = CANVAS_THEME.muted;
+        ctx.font = '9px "Segoe UI", sans-serif';
+        ctx.textAlign = "right";
+        ctx.fillText("host process + language worker process", right - 18, top + 24);
+        ctx.restore();
+      }
+
+      function drawOuterNode(node, accent, active, icon) {
+        const x = node.x - node.w / 2;
+        const y = node.y - node.h / 2;
+        ctx.save();
+        ctx.globalAlpha = active ? 1 : 0.5;
+        roundedRect(x, y, node.w, node.h, 5);
+        ctx.fillStyle = active ? CANVAS_THEME.nodeActive : CANVAS_THEME.node;
+        ctx.fill();
+        ctx.strokeStyle = active ? accent : CANVAS_THEME.border;
+        ctx.lineWidth = active ? 2 : 1;
+        ctx.stroke();
+
+        ctx.fillStyle = accent;
+        ctx.font = `700 ${Math.max(11, Math.min(16, node.w * 0.09))}px "Segoe UI", sans-serif`;
+        ctx.textAlign = "center";
+        ctx.fillText(icon, node.x, y + 30);
+
+        ctx.fillStyle = CANVAS_THEME.text;
+        ctx.font = `700 ${Math.max(11, Math.min(16, node.w * 0.095))}px "Segoe UI", sans-serif`;
+        ctx.fillText(node.label, node.x, y + 57);
+        ctx.fillStyle = CANVAS_THEME.muted;
+        ctx.font = `${Math.max(9, Math.min(11, node.w * 0.065))}px "Segoe UI", sans-serif`;
+        ctx.fillText(node.sub, node.x, y + 76);
+        ctx.restore();
+      }
+
+      function drawGrpc(active) {
+        const host = nodes.host;
+        const worker = nodes.worker;
+        const startX = host.x + host.w / 2;
+        const endX = worker.x - worker.w / 2;
+        const y = host.y;
+        const color = active ? COLORS.control : CANVAS_THEME.muted;
+
+        ctx.save();
+
+        ctx.strokeStyle = active ? CANVAS_THEME.pipeActive : CANVAS_THEME.pipeInactive;
+        ctx.lineWidth = 16;
+        ctx.lineCap = "round";
+        ctx.beginPath();
+        ctx.moveTo(startX, y);
+        ctx.lineTo(endX, y);
+        ctx.stroke();
+
+        ctx.strokeStyle = CANVAS_THEME.pipeCore;
+        ctx.lineWidth = 10;
+        ctx.beginPath();
+        ctx.moveTo(startX, y);
+        ctx.lineTo(endX, y);
+        ctx.stroke();
+
+        ctx.strokeStyle = color;
+        ctx.globalAlpha = active ? 0.72 : 0.42;
+        ctx.lineWidth = 1.5;
+        ctx.setLineDash([5, 5]);
+        ctx.beginPath();
+        ctx.moveTo(startX + 9, y - 4);
+        ctx.lineTo(endX - 9, y - 4);
+        ctx.moveTo(endX - 9, y + 4);
+        ctx.lineTo(startX + 9, y + 4);
+        ctx.stroke();
+        ctx.setLineDash([]);
+
+        drawPipeArrow(endX - 7, y - 4, 1, color);
+        drawPipeArrow(startX + 7, y + 4, -1, color);
+
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = active ? COLORS.control : CANVAS_THEME.muted;
+        ctx.font = '750 10px "Segoe UI", sans-serif';
+        ctx.textAlign = "center";
+        ctx.fillText("FunctionRpc gRPC pipe", (startX + endX) / 2, y - 21);
+        ctx.restore();
+      }
+
+      function drawPipeArrow(x, y, direction, color) {
+        ctx.save();
+        ctx.fillStyle = color;
+        ctx.beginPath();
+        ctx.moveTo(x + direction * 5, y);
+        ctx.lineTo(x - direction * 3, y - 3);
+        ctx.lineTo(x - direction * 3, y + 3);
+        ctx.closePath();
+        ctx.fill();
+        ctx.restore();
+      }
+
+      function drawWorker(step, progress) {
+        const worker = nodes.worker;
+        const x = worker.x - worker.w / 2;
+        const y = worker.y - worker.h / 2;
+        const activeWorker = ["worker", "dispatcher", "converter", "middleware", "function"].includes(step.from) ||
+          ["worker", "dispatcher", "converter", "middleware", "function"].includes(step.to);
+
+        ctx.save();
+        roundedRect(x, y, worker.w, worker.h, 6);
+        ctx.fillStyle = activeWorker ? CANVAS_THEME.workerActive : CANVAS_THEME.worker;
+        ctx.fill();
+        ctx.strokeStyle = activeWorker ? COLORS.go : CANVAS_THEME.border;
+        ctx.lineWidth = activeWorker ? 2 : 1;
+        ctx.stroke();
+
+        ctx.textAlign = "left";
+        ctx.fillStyle = COLORS.go;
+        ctx.font = `800 ${Math.max(12, Math.min(17, worker.w * 0.065))}px "Segoe UI", sans-serif`;
+        ctx.fillText("GO FUNCTION APP", x + 18, y + 27);
+
+        const innerNames = activeJourney === 0
+          ? ["dispatcher", "registry"]
+          : ["dispatcher", "converter", "middleware", "function"];
+        innerNames.forEach((name, index) => {
+          const node = nodes[name];
+          const nx = node.x - node.w / 2;
+          const ny = node.y - node.h / 2;
+          const isActive = step.from === name || step.to === name ||
+            (name === "registry" && currentStep >= 4);
+          ctx.globalAlpha = isActive ? 1 : 0.48;
+          roundedRect(nx, ny, node.w, node.h, 4);
+          ctx.fillStyle = isActive ? CANVAS_THEME.innerActive : CANVAS_THEME.node;
+          ctx.fill();
+          ctx.strokeStyle = isActive ? COLORS[step.type] : CANVAS_THEME.border;
+          ctx.lineWidth = isActive ? 1.7 : 1;
+          ctx.stroke();
+
+          ctx.textAlign = "left";
+          ctx.fillStyle = CANVAS_THEME.text;
+          ctx.font = `700 ${Math.max(9, Math.min(12, node.w * 0.055))}px "Segoe UI", sans-serif`;
+          ctx.fillText(node.label, nx + 12, ny + node.h * 0.45);
+          ctx.fillStyle = CANVAS_THEME.muted;
+          ctx.font = `${Math.max(7, Math.min(9, node.w * 0.04))}px "Segoe UI", sans-serif`;
+          ctx.fillText(node.sub, nx + 12, ny + node.h * 0.72);
+          ctx.globalAlpha = 1;
+
+          if (index < innerNames.length - 1) {
+            const next = nodes[innerNames[index + 1]];
+            ctx.strokeStyle = COLORS.go;
+            ctx.globalAlpha = 0.28;
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(node.x, node.y + node.h / 2);
+            ctx.lineTo(next.x, next.y - next.h / 2);
+            ctx.stroke();
+            ctx.globalAlpha = 1;
+          }
+        });
+        ctx.restore();
+      }
+
+      function pointOnRoute(fromName, toName, progress) {
+        const from = nodes[fromName];
+        const to = nodes[toName];
+        const internal = ["dispatcher", "converter", "middleware", "function"];
+        const fromInternal = internal.includes(fromName);
+        const toInternal = internal.includes(toName);
+        const triggerToHost = fromName === "trigger" && toName === "host";
+        const points = [{
+          x: triggerToHost ? from.x + from.w / 2 : from.x,
+          y: from.y
+        }];
+
+        if (!fromInternal && toInternal) {
+          points.push({ x: nodes.worker.x - nodes.worker.w / 2 - 18, y: from.y });
+          points.push({ x: nodes.worker.x - nodes.worker.w / 2 - 18, y: to.y });
+        } else if (fromInternal && !toInternal) {
+          points.push({ x: nodes.worker.x - nodes.worker.w / 2 - 18, y: from.y });
+          points.push({ x: nodes.worker.x - nodes.worker.w / 2 - 18, y: to.y });
+        }
+
+        if ((fromName === "host" && toInternal) || (fromInternal && toName === "host") ||
+            (fromName === "worker" && toName === "host") || (fromName === "host" && toName === "worker")) {
+          points.splice(points.length - (toInternal || fromInternal ? 0 : 0), 0, { x: nodes.grpc.x, y: from.y });
+        }
+
+        points.push({
+          x: triggerToHost ? to.x - to.w / 2 : to.x,
+          y: to.y
+        });
+
+        const segments = [];
+        let total = 0;
+        for (let i = 0; i < points.length - 1; i++) {
+          const dx = points[i + 1].x - points[i].x;
+          const dy = points[i + 1].y - points[i].y;
+          const length = Math.hypot(dx, dy);
+          segments.push({ from: points[i], to: points[i + 1], length });
+          total += length;
+        }
+
+        let distance = progress * total;
+        for (const segment of segments) {
+          if (distance <= segment.length) {
+            const p = segment.length === 0 ? 1 : distance / segment.length;
+            return {
+              x: segment.from.x + (segment.to.x - segment.from.x) * p,
+              y: segment.from.y + (segment.to.y - segment.from.y) * p
+            };
+          }
+          distance -= segment.length;
+        }
+        return points[points.length - 1];
+      }
+
+      function drawPacket(step, progress) {
+        const color = COLORS[step.type];
+        const point = pointOnRoute(step.from, step.to, progress);
+
+        ctx.save();
+        ctx.fillStyle = color;
+        ctx.fillRect(point.x - 4, point.y - 4, 8, 8);
+        ctx.restore();
+      }
+
+      function draw(now) {
+        ctx.clearRect(0, 0, width, height);
+        ctx.fillStyle = CANVAS_THEME.background;
+        ctx.fillRect(0, 0, width, height);
+        drawContainer();
+        drawBaseConnections();
+
+        const step = steps[currentStep];
+        const duration = step.duration / speed;
+        const elapsed = (playing ? now : pausedAt || now) - stepStartedAt;
+        const cycleProgress = reducedMotion && !playing ? 1 : Math.min(1, Math.max(0, elapsed / duration));
+        const packetProgress = Math.min(1, cycleProgress / 0.78);
+
+        if (activeJourney === 1) {
+          drawOuterNode(nodes.trigger, COLORS.invoke, step.from === "trigger" || step.to === "trigger", "EVENT");
+        }
+        drawOuterNode(nodes.host, COLORS.azure, step.from === "host" || step.to === "host", "AZURE");
+        drawGrpc(step.from === "host" || step.to === "host" || step.from === "worker" || step.to === "worker");
+        drawWorker(step, packetProgress);
+        drawPacket(step, packetProgress);
+
+        if (playing && elapsed >= duration) {
+          const journey = journeys[activeJourney];
+          if (currentStep === journey.end) {
+            playing = false;
+            pausedAt = now;
+            setPlayButton("replay");
+          } else {
+            setStep(currentStep + 1, true);
+          }
+        }
+        requestAnimationFrame(draw);
+      }
+
+      playButton.addEventListener("click", togglePlaying);
+      previousButton.addEventListener("click", () => moveStep(-1));
+      nextButton.addEventListener("click", () => moveStep(1));
+      window.addEventListener("resize", resize);
+      window.addEventListener("keydown", event => {
+        if (event.key === " " && event.target.tagName !== "INPUT") {
+          event.preventDefault();
+          togglePlaying();
+        } else if (event.key === "ArrowRight") {
+          moveStep(1);
+        } else if (event.key === "ArrowLeft") {
+          moveStep(-1);
+        }
+      });
+
+      syncTheme();
+      watchTheme();
+      createJourneyNav();
+      createHostMessageLegend();
+      renderTimeline();
+      resize();
+      setStep(0, true);
+      updateJourneyNav();
+      if (reducedMotion) {
+        playing = false;
+        setPlayButton("play");
+        pausedAt = performance.now();
+      } else {
+        setPlayButton("pause");
+      }
+      requestAnimationFrame(draw);
+    })();
+  </script>
+</body>
+</html>

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -1,4 +1,69 @@
 # Architecture
 
-Understand how the Go worker communicates with the Azure Functions host and
-executes function invocations.
+The Azure Functions host and compiled Go Function App run as separate
+processes. The host manages triggers and invocation orchestration. The Go app
+contains the worker SDK, registered functions, bindings, middleware, and
+customer code.
+
+They communicate through the bidirectional `FunctionRpc.EventStream` gRPC
+connection.
+
+## Explore the Host-Worker Protocol
+
+The visualization separates startup and host negotiation from customer request
+processing. Choose a story and phase to follow the primary message flow.
+
+<iframe
+  src="../../assets/host-worker-visualization.html"
+  title="Azure Functions host and Go worker protocol visualization"
+  style="width: 100%; height: 920px; border: 0; border-radius: 12px;"
+  loading="lazy">
+</iframe>
+
+<small><a href="../../assets/host-worker-visualization.html">Open visualization</a></small>
+
+## Responsibilities
+
+| Azure Functions host | Go Function App |
+| --- | --- |
+| Listens for triggers | Registers functions in code |
+| Orchestrates invocations | Reports function metadata |
+| Sends binding data | Converts inputs into Go values |
+| Applies output bindings | Runs middleware and customer code |
+| Manages process lifecycle | Returns results and logs |
+
+## Lifecycle at a glance
+
+### Startup
+
+1. The host launches the compiled Go app.
+2. The app opens the gRPC stream and sends `StartStream`.
+3. The host initializes the app with `WorkerInitRequest`.
+4. The app reports its capabilities and registered function metadata.
+5. The host loads each function by ID.
+
+### Invocation
+
+1. A trigger reaches the host.
+2. The host sends an `InvocationRequest`.
+3. The app prepares the invocation context and converts binding inputs.
+4. Middleware and customer code execute.
+5. Logs and the `InvocationResponse` return through the gRPC stream.
+
+## Important variations
+
+The interactive diagram shows the primary gRPC payload path. Some workloads use
+additional mechanisms:
+
+- Core trigger payloads travel inline in `InvocationRequest`.
+- Extension triggers may receive metadata and an injected Azure SDK client.
+- HTTP streaming can use an additional loopback HTTP path.
+- Consumption deployments launch the app through the worker proxy.
+
+## Related documentation
+
+- [Triggers and bindings](triggers-and-bindings.md)
+- [Logging and observability](../guides/observability.md)
+- [Error and panic handling](../guides/error-handling.md)
+- [Deployment](../guides/deployment.md)
+- [Technical specification](https://github.com/Azure/azure-functions-golang-worker/blob/main/TECHNICAL_SPEC.md)

--- a/docs/concepts/triggers-and-bindings.md
+++ b/docs/concepts/triggers-and-bindings.md
@@ -2,3 +2,81 @@
 
 Understand the trigger models, binding configuration, and handler signatures
 supported by the Go worker.
+
+## Trigger models
+
+A trigger starts a function invocation. The Azure Functions host listens to the
+configured service and dispatches the invocation to the Go app. Trigger
+configuration is registered through methods on `sdk.App` and reported to the
+host during worker-driven indexing.
+
+### Core triggers
+
+Core triggers receive bounded invocation data from the host. The worker
+converts the protocol payload into a typed Go value before calling the handler.
+These triggers do not require an Azure SDK dependency in the compiled app.
+
+HTTP is a special case. When the loopback HTTP listener is available, the host
+proxies the request and response over HTTP to support streaming while gRPC
+carries invocation correlation data. The worker falls back to buffered gRPC
+HTTP payloads if proxying is unavailable or disabled.
+
+### Extension triggers
+
+Extension triggers are used when a resource can be large or the handler needs
+streaming, random access, or write-back operations. The host sends resource
+metadata instead of the full payload, and the worker injects an authenticated
+Azure SDK client scoped to the triggering resource.
+
+This model is more efficient for large resources because the host does not read,
+serialize, and funnel the resource content through the gRPC channel. The worker
+receives the metadata needed to create the client, and the handler streams or
+reads the data directly from the backing Azure service. This reduces host and
+worker memory pressure and avoids an extra copy through the invocation
+protocol, although the handler still makes a service request through the
+injected client.
+
+Extension dependencies are isolated under `triggers/<name>`. Import the
+extension package to register its client factory:
+
+```go
+import _ "github.com/azure/azure-functions-golang-worker/triggers/blob"
+```
+
+| Characteristic | Core trigger | Extension trigger |
+| --- | --- | --- |
+| Invocation data | Typed payload from the host | Resource metadata from the host |
+| Handler argument | SDK binding type | Azure SDK client |
+| External Azure SDK dependency | No | Yes, isolated in the extension module |
+| Typical payload | Bounded messages, events, or change batches | Potentially large resources |
+| Access pattern | Deserialize and process | Stream, seek, or write through the client |
+
+## Supported triggers
+
+| Trigger | Model | Registration method | Handler signature |
+| --- | --- | --- | --- |
+| HTTP | Core | `app.HTTP` | `func(http.ResponseWriter, *http.Request)` |
+| Timer | Core | `app.Timer` | `func(context.Context, bindings.TimerInfo) error` |
+| Azure Queue Storage | Core | `app.Queue` | `func(context.Context, bindings.QueueMessage) error` |
+| Azure Cosmos DB | Core | `app.CosmosDB` | `func(context.Context, []bindings.CosmosDocument) error` |
+| Azure Event Grid | Core | `app.EventGrid` | `func(context.Context, bindings.EventGridEvent) error` |
+| Azure Event Hubs | Core | `app.EventHub` | `func(context.Context, bindings.EventHubMessage) error` |
+| Azure Service Bus queue | Core | `app.ServiceBusQueue` | `func(context.Context, bindings.ServiceBusMessage) error` |
+| Azure Service Bus topic | Core | `app.ServiceBusTopic` | `func(context.Context, bindings.ServiceBusMessage) error` |
+| Azure SQL | Core | `app.SQL` | `func(context.Context, []bindings.SQLChange) error` |
+| Azure Blob Storage | Extension | `app.Blob` | `func(context.Context, *blob.Client) error` |
+
+See the [samples](../samples/index.md) for complete registration and handler
+examples.
+
+## Binding support
+
+The current Go worker supports the trigger bindings listed above and the
+implicit HTTP `$return` output binding, which is exposed through
+`http.ResponseWriter`. Additional input bindings and non-HTTP output bindings
+are not currently supported.
+
+Registration options such as `sdk.WithQueueName`, `sdk.WithConnection`,
+`sdk.WithConsumerGroup`, and `sdk.WithTable` configure the trigger binding
+metadata sent to the host. Connection options name an application setting; they
+do not contain the connection string itself.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ running Go applications natively on Azure Functions.
 ## Documentation
 
 - [Getting started](getting-started.md)
+- [Roadmap](roadmap.md)
 - Concepts
   - [Architecture](concepts/architecture.md)
   - [Triggers and bindings](concepts/triggers-and-bindings.md)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -46,6 +46,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting started: getting-started.md
+  - Roadmap: roadmap.md
   - Concepts:
       - Architecture: concepts/architecture.md
       - Triggers and bindings: concepts/triggers-and-bindings.md

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,41 @@
+# Roadmap
+
+Go support for Azure Functions is currently in public preview. This page shows
+the current support surface and areas being explored.
+
+## Hosting plans
+
+| Plan | Status |
+| --- | --- |
+| Flex Consumption | Public preview; GA is on the roadmap |
+| Elastic Premium | On the roadmap |
+| Dedicated (Linux App Service plan) | On the roadmap |
+
+Go applications must target Linux x64 with CGO disabled
+(`CGO_ENABLED=0`). Windows is not supported.
+
+## Triggers
+
+| Trigger | Status | Notes |
+| --- | --- | --- |
+| HTTP | Supported | Includes HTTP streaming |
+| Timer | Supported | |
+| Azure Queue Storage | Supported | |
+| Azure Blob Storage | Supported | Uses Azure SDK client injection |
+| Azure Cosmos DB | Supported | |
+| Azure Event Grid | Supported | |
+| Azure Event Hubs | Supported | |
+| Azure Service Bus queues and topics | Supported | |
+| Azure SQL | Supported | |
+
+## Capabilities
+
+| Capability | Status | Notes |
+| --- | --- | --- |
+| Deferred bindings | On the roadmap | SDK-typed trigger and input bindings |
+| Durable Functions | On the roadmap | |
+
+!!! tip "Help shape the roadmap"
+    Don't see the hosting plan, trigger, binding, or feature you need?
+    [File a GitHub issue](https://github.com/Azure/azure-functions-golang-worker/issues/new/choose)
+    and describe your scenario.


### PR DESCRIPTION
## Summary

- Add an interactive visualization of the host-worker startup and invocation protocol.
- Expand architecture documentation with lifecycle, responsibilities, and protocol variations.
- Document core versus extension triggers, supported handler signatures, and current binding support.
- Add a roadmap covering hosting plans, triggers, and planned capabilities.
- Add the new roadmap to the documentation navigation.

## Validation

- `mkdocs build --config-file docs/mkdocs.yml --strict`
